### PR TITLE
Fix that music delivery is not always resumed

### DIFF
--- a/mopidy_spotify/playback.py
+++ b/mopidy_spotify/playback.py
@@ -72,6 +72,10 @@ class SpotifyPlaybackProvider(backend.PlaybackProvider):
             logger.info('Playback of %s failed: %s', track.uri, e)
             return False
 
+    def resume(self):
+        self.backend.spotify.session.play(1)
+        return super(SpotifyPlaybackProvider, self).resume()
+
     def stop(self):
         self.backend.spotify.session.play(0)
         return super(SpotifyPlaybackProvider, self).stop()


### PR DESCRIPTION
When playback is paused by play_token_lost (e.g. another client on the
same account started playing), and then resumed, music delivery will not
continue. Therefore, the music will play as long as the buffer lasts,
and then go silent until you change track. This commit makes music
delivery continue after resume.

If we're lucky, this also fixes #2.
