### PR TITLE
Search: loop by track

### DIFF
--- a/mopidy_spotify/library.py
+++ b/mopidy_spotify/library.py
@@ -63,20 +63,13 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
     def _lookup_artist(self, sp_link):
         sp_artist = sp_link.as_artist()
         sp_artist_browser = sp_artist.browse(
-            type=spotify.ArtistBrowserType.NO_TRACKS)
+            type=spotify.ArtistBrowserType.FULL)
         sp_artist_browser.load()
-        for sp_album in sp_artist_browser.albums:
-            sp_album_browser = sp_album.browse()
-            sp_album_browser.load()
-            if sp_album.type is spotify.AlbumType.COMPILATION:
-                continue
-            if sp_album.artist.link.uri in VARIOUS_ARTISTS_URIS:
-                continue
-            for sp_track in sp_album_browser.tracks:
-                track = translator.to_track(
-                    sp_track, bitrate=self._backend._bitrate)
-                if track is not None:
-                    yield track
+        for sp_track in sp_artist_browser.tracks:
+            track = translator.to_track(
+                sp_track, bitrate=self._backend._bitrate)
+            if track is not None:
+                yield track
 
     def _lookup_playlist(self, sp_link):
         sp_playlist = sp_link.as_playlist()


### PR DESCRIPTION
I don't expect this to be merged.  I haven't tested manually or run the test suite.  So there is a good chance that it breaks functionality.  I figured this was the easiest way to illustrate the performance regression that I am observing.

For me this diff when trying to add the search results for Avicii to now playing reduces the add time from over a minute to under 1 second.

Let me know in my bug report if you can reproduce/agree on this problem, and I will look at getting together a pull request that could be merged.

<!---
@huboard:{"order":31.0,"milestone_order":31,"custom_state":""}
-->
