### PR TITLE
Cache playlists

### DIFF
--- a/mopidy_spotify/__init__.py
+++ b/mopidy_spotify/__init__.py
@@ -40,6 +40,7 @@ class Extension(ext.Extension):
         schema['search_track_count'] = config.Integer(minimum=0, maximum=200)
 
         schema['toplist_countries'] = config.List(optional=True)
+        schema['dontcache'] = config.Boolean(optional=True)
 
         return schema
 

--- a/mopidy_spotify/ext.conf
+++ b/mopidy_spotify/ext.conf
@@ -13,3 +13,4 @@ search_album_count = 20
 search_artist_count = 10
 search_track_count = 50
 toplist_countries = AD,AR,AU,AT,BE,CO,CY,DK,EE,FI,FR,DE,GR,HK,IS,IE,IT,LV,LI,LT,LU,MY,MX,MC,NL,NZ,NO,PT,ES,SG,SE,CH,TW,TR,GB,US
+dontcache = false

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -17,6 +17,7 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
 
     def __init__(self, backend):
         self._backend = backend
+        self.cachedResult=None
 
         # TODO Listen to playlist events
 
@@ -63,8 +64,15 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
 
         if self._backend._session.playlist_container is None:
             return []
-
+        
         start = time.time()
+        
+        dontcache = self._backend._config['spotify']['dontcache']
+
+        if not dontcache and self.cachedResult:
+            logger.info("Playlists.. returned cache result")
+            return self.cachedResult;
+        
 
         username = self._backend._session.user_name
         result = []
@@ -87,10 +95,11 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
         # TODO Add starred playlist
 
         logger.debug('Playlists fetched in %.3fs', time.time() - start)
+        self.cachedResult=result
         return result
 
     def refresh(self):
-        pass  # Not needed as long as we don't cache anything.
+        self.cachedResult=None
 
     def save(self, playlist):
         pass  # TODO


### PR DESCRIPTION
Simple update to allow playlists to be cached.
Once spotify has been contacted then the playlist info is cache in memory, saving having to retrieve it each time any request is processed.

Added config option to disable this
spotify/dontcache=True  will disable it