### PR TITLE
Offline spotify playlist

### DIFF
--- a/mopidy_spotify/__init__.py
+++ b/mopidy_spotify/__init__.py
@@ -28,6 +28,7 @@ class Extension(ext.Extension):
         schema['volume_normalization'] = config.Boolean()
 
         schema['timeout'] = config.Integer(minimum=0)
+        schema['offlinepl'] = config.List(optional=True)
 
         schema['cache_dir'] = config.Path(optional=True)
         schema['settings_dir'] = config.Path()

--- a/mopidy_spotify/backend.py
+++ b/mopidy_spotify/backend.py
@@ -81,6 +81,12 @@ class SpotifyBackend(pykka.ThreadingActor, backend.Backend):
         session.on(
             spotify.SessionEvent.PLAY_TOKEN_LOST,
             on_play_token_lost, self.actor_ref)
+        session.on(
+            spotify.SessionEvent.MESSAGE_TO_USER,
+            on_msg_to_user)
+        session.on(
+            spotify.SessionEvent.LOG_MESSAGE,
+            on_logmessage)
 
         return session
 
@@ -132,3 +138,10 @@ def on_play_token_lost(session, actor_ref):
     # Called from the pyspotify event loop, and not in an actor context.
     logger.debug('Spotify play token lost')
     actor_ref.tell({'event': 'play_token_lost'})
+def on_msg_to_user(session, data):
+    # Called from the pyspotify event loop, and not in an actor context.
+    logger.info('Spotify message to user:'+`data`)
+
+def on_logmessage(session, data):
+    # Called from the pyspotify event loop, and not in an actor context.
+    logger.debug('Spotify:'+`data`)

--- a/mopidy_spotify/ext.conf
+++ b/mopidy_spotify/ext.conf
@@ -5,6 +5,7 @@ password =
 bitrate = 160
 volume_normalization = true
 timeout = 10
+offlinepl =
 cache_dir = $XDG_CACHE_DIR/mopidy/spotify
 settings_dir = $XDG_CONFIG_DIR/mopidy/spotify
 allow_network = true

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import logging
 import time
+import re
 
 from mopidy import backend
 
@@ -60,16 +61,35 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
 
         if self._backend._session is None:
             return []
+        
+        offlinecount=self._backend._session.offline.num_playlists
+        logger.info("offline playlist count:"+`offlinecount`)
+        if offlinecount>0:
+	        syncstatus = self._backend._session.offline.sync_status;
+		if syncstatus:
+		        queued = self._backend._session.offline.sync_status.queued_tracks;
+       	 		done = self._backend._session.offline.sync_status.done_tracks;
+       	 		errored = self._backend._session.offline.sync_status.error_tracks;
+        		logger.info("Offline sync status: Queued="+`queued`+",Done="+`done`+",Error="+`errored`);
+                else:
+                      	logger.info("Offline sync status: Not syncing")
 
+	        seconds = self._backend._session.offline.time_left;
+       	 	logger.info("Time (hours) left until user must go online:"+`seconds/60/60`); 
+                
         if self._backend._session.playlist_container is None:
             return []
-
+        
         start = time.time()
+        
+      
+        offlineplaylists = self._backend._config['spotify']['offlinepl']
+        trackcounting={}
 
         username = self._backend._session.user_name
         result = []
         folders = []
-
+	
         for sp_playlist in self._backend._session.playlist_container:
             if isinstance(sp_playlist, spotify.PlaylistFolder):
                 if sp_playlist.type is spotify.PlaylistType.START_FOLDER:
@@ -83,7 +103,33 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
                 bitrate=self._backend._bitrate)
             if playlist is not None:
                 result.append(playlist)
+	        logger.info("loaded playlist:"+`playlist.name`+" offline status="+`sp_playlist.offline_status`+" tracks:"+`len(sp_playlist.tracks)`)
+                counting={}
+                for track in sp_playlist.tracks:     
+                    if not track.offline_status in counting:
+                        counting[track.offline_status]=1
+                    else:
+                        counting[track.offline_status]+=1
+                    if not track.offline_status in trackcounting:
+                        trackcounting[track.offline_status]=1
+                    else:
+                        trackcounting[track.offline_status]+=1
+                        
+                offline=False
+		for pl in offlineplaylists:
+			p = re.compile(pl);
+			if p.match(sp_playlist.name):
+				offline=True		
 
+		if offline and sp_playlist.offline_status==spotify.PlaylistOfflineStatus.NO:
+			logger.info("Offline playlist:"+`sp_playlist.name`+`sp_playlist.offline_status`);
+			sp_playlist.set_offline_mode(offline=True);		
+		if not offline and sp_playlist.offline_status!=spotify.PlaylistOfflineStatus.NO:
+			logger.info("Online playlist:"+`sp_playlist.name`+`sp_playlist.offline_status`);
+			sp_playlist.set_offline_mode(offline=False);
+
+        logger.info("Track totals:"+`trackcounting`)
+        info = self._backend._session.offline.tracks_to_sync;
         # TODO Add starred playlist
 
         logger.debug('Playlists fetched in %.3fs', time.time() - start)


### PR DESCRIPTION
Add option to spotify config that will set playlists offline.

This uses the pyspotify functions to do all the work.

User can set playlists to be offline using config

[spotify]
offlinepl = PlaylistName,Playlist2
also wild cards are supported

[spotify]
offlinepl = Playlist.*
