### PR TITLE
config: Add private_session config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,10 @@ The following configuration values are available:
   domains to get toplists for. Defaults to a long list of countries which
   Spotify is available in.
 
-- ``spotify/private_session``: Whether to use a private Spotify session.
+- ``spotify/private_session``: Whether to use a private Spotify session. Turn
+  on private session to disable sharing of played tracks with friends through
+  the Spotify activity feed, Last.fm scrobbling, and Facebook. This only
+  affects social sharing done by Spotify, not by other Mopidy extensions.
   Defaults to ``false``.
 
 

--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,9 @@ The following configuration values are available:
   domains to get toplists for. Defaults to a long list of countries which
   Spotify is available in.
 
+- ``spotify/private_session``: Whether to use a private Spotify session.
+  Defaults to ``false``.
+
 
 Project resources
 =================
@@ -162,6 +165,8 @@ v2.0.0 (UNRELEASED)
 - Make maximum number of returned results configurable through
   ``spotify/search_album_count``, ``spotify/search_artist_count``, and
   ``spotify/search_track_count``.
+
+- Add ``spotify/private_session`` config.
 
 **Lookup**
 

--- a/mopidy_spotify/__init__.py
+++ b/mopidy_spotify/__init__.py
@@ -26,6 +26,7 @@ class Extension(ext.Extension):
 
         schema['bitrate'] = config.Integer(choices=(96, 160, 320))
         schema['volume_normalization'] = config.Boolean()
+        schema['private_session'] = config.Boolean()
 
         schema['timeout'] = config.Integer(minimum=0)
 

--- a/mopidy_spotify/backend.py
+++ b/mopidy_spotify/backend.py
@@ -73,6 +73,8 @@ class SpotifyBackend(pykka.ThreadingActor, backend.Backend):
         session.preferred_bitrate = BITRATES[self._bitrate]
         session.volume_normalization = (
             config['spotify']['volume_normalization'])
+        session.social.private_session = (
+            config['spotify']['private_session'])
 
         session.on(
             spotify.SessionEvent.CONNECTION_STATE_UPDATED,

--- a/mopidy_spotify/ext.conf
+++ b/mopidy_spotify/ext.conf
@@ -4,6 +4,7 @@ username =
 password =
 bitrate = 160
 volume_normalization = true
+private_session = false
 timeout = 10
 cache_dir = $XDG_CACHE_DIR/mopidy/spotify
 settings_dir = $XDG_CONFIG_DIR/mopidy/spotify

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ def config():
             'password': 'password',
             'bitrate': 160,
             'volume_normalization': True,
+            'private_session': False,
             'timeout': 10,
             'cache_dir': '/my/cache/dir',
             'settings_dir': '/my/settings/dir',

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -77,6 +77,17 @@ def test_on_start_configures_volume_normalization(spotify_mock, config):
     volume_normalization_mock.assert_called_once_with(False)
 
 
+def test_on_start_configures_private_session(spotify_mock, config):
+    session = spotify_mock.Session.return_value
+    private_session_mock = mock.PropertyMock()
+    type(session).private_session = private_session_mock
+    config['spotify']['private_session'] = True
+
+    get_backend(config).on_start()
+
+    private_session_mock.assert_called_once_with(True)
+
+
 def test_on_start_adds_connection_state_changed_handler_to_session(
         spotify_mock, config):
     session = spotify_mock.Session.return_value

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -80,7 +80,7 @@ def test_on_start_configures_volume_normalization(spotify_mock, config):
 def test_on_start_configures_private_session(spotify_mock, config):
     session = spotify_mock.Session.return_value
     private_session_mock = mock.PropertyMock()
-    type(session).private_session = private_session_mock
+    type(session.social).private_session = private_session_mock
     config['spotify']['private_session'] = True
 
     get_backend(config).on_start()

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -21,6 +21,7 @@ def test_get_config_schema():
     assert 'password' in schema
     assert 'bitrate' in schema
     assert 'volume_normalization' in schema
+    assert 'private_session' in schema
     assert 'timeout' in schema
     assert 'cache_dir' in schema
     assert 'settings_dir' in schema


### PR DESCRIPTION
Hello. Thanks so much for Mopidy and the Spotify extension!

I occasionally find myself in situations in which I'd prefer my Spotify session to be private. This PR adds a `private_session` config value which can be used to do just that :smile: 