### PR TITLE
Add (temporary?) cover image support

### DIFF
--- a/mopidy_spotify/library.py
+++ b/mopidy_spotify/library.py
@@ -84,6 +84,7 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
         sp_artist_browser.load()
         top_tracks = list(translator.to_track_refs(
             sp_artist_browser.tophit_tracks))
+
         albums = list(translator.to_album_refs(sp_artist_browser.albums))
         return top_tracks + albums
 
@@ -242,11 +243,11 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
         sp_search.load()
 
         albums = [
-            translator.to_album(sp_album) for sp_album in sp_search.albums]
+            translator.to_album(sp_album, sp_album.cover(spotify.ImageSize.NORMAL).load()) for sp_album in sp_search.albums]
         artists = [
             translator.to_artist(sp_artist) for sp_artist in sp_search.artists]
         tracks = [
-            translator.to_track(sp_track) for sp_track in sp_search.tracks]
+            translator.to_track(sp_track, None, sp_track.album.cover(spotify.ImageSize.NORMAL).load()) for sp_track in sp_search.tracks]
 
         return models.SearchResult(
             uri=uri, albums=albums, artists=artists, tracks=tracks)

--- a/mopidy_spotify/library.py
+++ b/mopidy_spotify/library.py
@@ -242,12 +242,23 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
             track_count=spotify_config['search_track_count'])
         sp_search.load()
 
-        albums = [
-            translator.to_album(sp_album, sp_album.cover(spotify.ImageSize.NORMAL).load()) for sp_album in sp_search.albums]
+        # Collect albums
+        albums = []
+        for sp_album in sp_search.albums:
+            cover = sp_album.cover(spotify.ImageSize.NORMAL).load()
+            album = translator.to_album(sp_album, cover)
+            albums.append(album)
+
+        # Collect artists
         artists = [
             translator.to_artist(sp_artist) for sp_artist in sp_search.artists]
-        tracks = [
-            translator.to_track(sp_track, None, sp_track.album.cover(spotify.ImageSize.NORMAL).load()) for sp_track in sp_search.tracks]
+
+        # Collect tracks
+        tracks = []
+        for sp_track in sp_search.tracks:
+            cover = sp_track.album.cover(spotify.ImageSize.NORMAL).load()
+            track = translator.to_track(sp_track, None, cover)
+            tracks.append(track)
 
         return models.SearchResult(
             uri=uri, albums=albums, artists=artists, tracks=tracks)

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -54,7 +54,11 @@ def to_artist_refs(sp_artists):
 
 
 @memoized
-def to_album(sp_album):
+def to_album(sp_album, sp_image=None):
+    images = []
+    if sp_image is not None:
+        images = [sp_image.data_uri]
+
     if not sp_album.is_loaded:
         return
 
@@ -71,6 +75,7 @@ def to_album(sp_album):
     return models.Album(
         uri=sp_album.link.uri,
         name=sp_album.name,
+        images=images,
         artists=artists,
         date=date)
 
@@ -97,7 +102,7 @@ def to_album_refs(sp_albums):
 
 
 @memoized
-def to_track(sp_track, bitrate=None):
+def to_track(sp_track, bitrate=None, image=None):
     if not sp_track.is_loaded:
         return
 
@@ -112,7 +117,7 @@ def to_track(sp_track, bitrate=None):
     artists = [to_artist(sp_artist) for sp_artist in sp_track.artists]
     artists = filter(None, artists)
 
-    album = to_album(sp_track.album)
+    album = to_album(sp_track.album, image)
 
     return models.Track(
         uri=sp_track.link.uri,


### PR DESCRIPTION
Hi!

I have made a `hacky?` patch that adds cover art support (returning the data_uri)
This can be displayed with `background: url('the_base64_from_data_uri')` and `<img src="the_base64_from_date_uri" />`

I have read the discussion in https://github.com/mopidy/mopidy-spotify/issues/23
And I know a better solution is on it's way, but perhaps this can help other people out that want it right now.