### PR TITLE
Do not include 0 date albums for spotify searching

### DIFF
--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -44,7 +44,9 @@ def search(config, session, query=None, uris=None, exact=False):
     sp_search.load()
 
     albums = [
-        translator.to_album(sp_album) for sp_album in sp_search.albums]
+        translator.to_album(sp_album)
+        for sp_album in sp_search.albums
+        if sp_album.year != 0]
     artists = [
         translator.to_artist(sp_artist) for sp_artist in sp_search.artists]
     tracks = [


### PR DESCRIPTION
This commit solves issue #72 by not including spotify albums with a year of 0. This commit will obviously not include any of year 0, but the assumption is spotify (in my experience) will not have 0 years.