### PR TITLE
Ensure a playlist's tracks are all loaded when doing a lookup

### DIFF
--- a/mopidy_spotify/lookup.py
+++ b/mopidy_spotify/lookup.py
@@ -94,6 +94,7 @@ def _lookup_playlist(config, sp_link):
     sp_playlist = sp_link.as_playlist()
     sp_playlist.load()
     for sp_track in sp_playlist.tracks:
+        sp_track.load()
         track = translator.to_track(
             sp_track, bitrate=config['bitrate'])
         if track is not None:

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -144,6 +144,7 @@ def test_lookup_of_playlist_uri(session_mock, sp_playlist_mock, provider):
     session_mock.get_link.assert_called_once_with('spotify:playlist:alice:foo')
     sp_playlist_mock.link.as_playlist.assert_called_once_with()
     sp_playlist_mock.load.assert_called_once_with()
+    sp_playlist_mock.tracks[0].load.assert_called_once_with()
 
     assert len(results) == 1
     track = results[0]


### PR DESCRIPTION
This should fix the issue described in #81. 

Perhaps we should be calling load on tracks for all the lookup routines? 

I'm not sure what to do with the test. I tried to swap `sp_playlist_mock` for `sp_unloaded_playlist_mock` but that's not working at all.