### PR TITLE
Use the Web API for search

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,6 +156,8 @@ Bug fix release.
 - Require Mopidy < 2 as Mopidy 2.0 breaks the audio API with the upgrade to
   GStreamer 1.
 
+- Use the new Web API for search. Searching through libspotify has been
+  discontinued and is not working anymore. (Fixes: #89)
 
 v2.3.0 (2016-02-06)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -156,13 +156,13 @@ Bug fix release.
 - Require Mopidy < 2 as Mopidy 2.0 breaks the audio API with the upgrade to
   GStreamer 1.
 
-- Use the new Web API for search. Searching through libspotify has been
+- Use the new Spotify Web API for search. Searching through libspotify has been
   discontinued and is not working anymore. (Fixes: #89)
 
-- Emit a warning if `search_album_count`, `search_artist_count` or
-  `search_track_count` is greater than 50, and use 50 instead. This is because
-  this is the maximum value that the Web API allows. The maximum in the config
-  schema is not changed to not break existing configs.
+- Emit a warning if ``search_album_count``, ``search_artist_count`` or
+  ``search_track_count`` is greater than 50, and use 50 instead. This is
+  because this is the maximum value that the Spotify Web API allows. The
+  maximum in the config schema is not changed to not break existing configs.
 
 v2.3.0 (2016-02-06)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -159,9 +159,10 @@ Bug fix release.
 - Use the new Web API for search. Searching through libspotify has been
   discontinued and is not working anymore. (Fixes: #89)
 
-- Change the maximum value of search_album_count, search_artist_count and
-  search_track_count to 50, because this is the maximum value that the Web API
-  allows.
+- Emit a warning if `search_album_count`, `search_artist_count` or
+  `search_track_count` is greater than 50, and use 50 instead. This is because
+  this is the maximum value that the Web API allows. The maximum in the config
+  schema is not changed to not break existing configs.
 
 v2.3.0 (2016-02-06)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -111,13 +111,13 @@ The following configuration values are available:
   Defaults to ``true``.
 
 - ``spotify/search_album_count``: Maximum number of albums returned in search
-  results. Number between 0 and 200. Defaults to 20.
+  results. Number between 0 and 50. Defaults to 20.
 
 - ``spotify/search_artist_count``: Maximum number of artists returned in search
-  results. Number between 0 and 200. Defaults to 10.
+  results. Number between 0 and 50. Defaults to 10.
 
 - ``spotify/search_track_count``: Maximum number of tracks returned in search
-  results. Number between 0 and 200. Defaults to 50.
+  results. Number between 0 and 50. Defaults to 50.
 
 - ``spotify/toplist_countries``: Comma separated list of two letter ISO country
   codes to get toplists for. Defaults to blank, which is interpreted as all
@@ -158,6 +158,10 @@ Bug fix release.
 
 - Use the new Web API for search. Searching through libspotify has been
   discontinued and is not working anymore. (Fixes: #89)
+
+- Change the maximum value of search_album_count, search_artist_count and
+  search_track_count to 50, because this is the maximum value that the Web API
+  allows.
 
 v2.3.0 (2016-02-06)
 -------------------

--- a/mopidy_spotify/__init__.py
+++ b/mopidy_spotify/__init__.py
@@ -37,9 +37,9 @@ class Extension(ext.Extension):
         schema['allow_network'] = config.Boolean()
         schema['allow_playlists'] = config.Boolean()
 
-        schema['search_album_count'] = config.Integer(minimum=0, maximum=200)
-        schema['search_artist_count'] = config.Integer(minimum=0, maximum=200)
-        schema['search_track_count'] = config.Integer(minimum=0, maximum=200)
+        schema['search_album_count'] = config.Integer(minimum=0, maximum=50)
+        schema['search_artist_count'] = config.Integer(minimum=0, maximum=50)
+        schema['search_track_count'] = config.Integer(minimum=0, maximum=50)
 
         schema['toplist_countries'] = config.List(optional=True)
 

--- a/mopidy_spotify/__init__.py
+++ b/mopidy_spotify/__init__.py
@@ -37,9 +37,9 @@ class Extension(ext.Extension):
         schema['allow_network'] = config.Boolean()
         schema['allow_playlists'] = config.Boolean()
 
-        schema['search_album_count'] = config.Integer(minimum=0, maximum=50)
-        schema['search_artist_count'] = config.Integer(minimum=0, maximum=50)
-        schema['search_track_count'] = config.Integer(minimum=0, maximum=50)
+        schema['search_album_count'] = config.Integer(minimum=0, maximum=200)
+        schema['search_artist_count'] = config.Integer(minimum=0, maximum=200)
+        schema['search_track_count'] = config.Integer(minimum=0, maximum=200)
 
         schema['toplist_countries'] = config.List(optional=True)
 

--- a/mopidy_spotify/library.py
+++ b/mopidy_spotify/library.py
@@ -38,5 +38,5 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
 
     def search(self, query=None, uris=None, exact=False):
         return search.search(
-            self._config, self._backend._session,
+            self._config, self._backend._session, self._requests_session,
             query, uris, exact)

--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -47,6 +47,13 @@ def search(config, session, requests_session,
         config['search_artist_count'],
         config['search_track_count'])
 
+    if search_count > 50:
+        logger.warn(
+            'Spotify currently allows maximum 50 search results of each type. '
+            'Please set the config options `search_album_count`, '
+            '`search_artist_count` and `search_track_count` to at most 50.')
+        search_count = 50
+
     try:
         response = requests_session.get(_API_BASE_URI, params={
             'q': sp_query,

--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -50,8 +50,9 @@ def search(config, session, requests_session,
     if search_count > 50:
         logger.warn(
             'Spotify currently allows maximum 50 search results of each type. '
-            'Please set the config options `search_album_count`, '
-            '`search_artist_count` and `search_track_count` to at most 50.')
+            'Please set the config values spotify/search_album_count, '
+            'spotify/search_artist_count and spotify/search_track_count '
+            'to at most 50.')
         search_count = 50
 
     try:

--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -63,13 +63,13 @@ def search(config, session, requests_session,
         return models.SearchResult(uri=uri)
 
     albums = [
-        translator.webapi_to_album(sp_album) for sp_album in
+        translator.web_to_album(web_album) for web_album in
         result['albums']['items'][:config['search_album_count']]]
     artists = [
-        translator.webapi_to_artist(sp_artist) for sp_artist in
+        translator.web_to_artist(web_artist) for web_artist in
         result['artists']['items'][:config['search_artist_count']]]
     tracks = [
-        translator.webapi_to_track(sp_track) for sp_track in
+        translator.web_to_track(web_track) for web_track in
         result['tracks']['items'][:config['search_track_count']]]
 
     return models.SearchResult(

--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -42,10 +42,15 @@ def search(config, session, requests_session,
         logger.info('Spotify search aborted: Spotify is offline')
         return models.SearchResult(uri=uri)
 
+    search_count = max(
+        config['search_album_count'],
+        config['search_artist_count'],
+        config['search_track_count'])
+
     try:
         response = requests_session.get(_API_BASE_URI, params={
             'q': sp_query,
-            'limit': config['search_track_count'],
+            'limit': search_count,
             'type': _SEARCH_TYPES})
     except requests.RequestException as exc:
         logger.debug('Fetching %s failed: %s', uri, exc)
@@ -58,14 +63,14 @@ def search(config, session, requests_session,
         return models.SearchResult(uri=uri)
 
     albums = [
-        translator.webapi_to_album(sp_album)
-        for sp_album in result['albums']['items']]
+        translator.webapi_to_album(sp_album) for sp_album in
+        result['albums']['items'][:config['search_album_count']]]
     artists = [
-        translator.webapi_to_artist(sp_artist)
-        for sp_artist in result['artists']['items']]
+        translator.webapi_to_artist(sp_artist) for sp_artist in
+        result['artists']['items'][:config['search_artist_count']]]
     tracks = [
-        translator.webapi_to_track(sp_track)
-        for sp_track in result['tracks']['items']]
+        translator.webapi_to_track(sp_track) for sp_track in
+        result['tracks']['items'][:config['search_track_count']]]
 
     return models.SearchResult(
         uri=uri, albums=albums, artists=artists, tracks=tracks)

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -232,3 +232,27 @@ def _transform_year(date):
         logger.debug(
             'Excluded year from search query: '
             'Cannot parse date "%s"', date)
+
+
+def webapi_to_artist(sp_artist):
+    return models.Artist(uri=sp_artist['uri'], name=sp_artist['name'])
+
+
+def webapi_to_album(sp_album):
+    return models.Album(uri=sp_album['uri'], name=sp_album['name'])
+
+
+def webapi_to_track(sp_track):
+    artists = [
+        webapi_to_artist(sp_artist)
+        for sp_artist in sp_track['artists']]
+    album = webapi_to_album(sp_track['album'])
+
+    return models.Track(
+        uri=sp_track['uri'],
+        name=sp_track['name'],
+        artists=artists,
+        album=album,
+        length=sp_track['duration_ms'],
+        disc_no=sp_track['disc_number'],
+        track_no=sp_track['track_number'])

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -234,25 +234,24 @@ def _transform_year(date):
             'Cannot parse date "%s"', date)
 
 
-def webapi_to_artist(sp_artist):
-    return models.Artist(uri=sp_artist['uri'], name=sp_artist['name'])
+def web_to_artist(web_artist):
+    return models.Artist(uri=web_artist['uri'], name=web_artist['name'])
 
 
-def webapi_to_album(sp_album):
-    return models.Album(uri=sp_album['uri'], name=sp_album['name'])
+def web_to_album(web_album):
+    return models.Album(uri=web_album['uri'], name=web_album['name'])
 
 
-def webapi_to_track(sp_track):
+def web_to_track(web_track):
     artists = [
-        webapi_to_artist(sp_artist)
-        for sp_artist in sp_track['artists']]
-    album = webapi_to_album(sp_track['album'])
+        web_to_artist(web_artist) for web_artist in web_track['artists']]
+    album = web_to_album(web_track['album'])
 
     return models.Track(
-        uri=sp_track['uri'],
-        name=sp_track['name'],
+        uri=web_track['uri'],
+        name=web_track['name'],
         artists=artists,
         album=album,
-        length=sp_track['duration_ms'],
-        disc_no=sp_track['disc_number'],
-        track_no=sp_track['track_number'])
+        length=web_track['duration_ms'],
+        disc_no=web_track['disc_number'],
+        track_no=web_track['track_number'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,39 +272,39 @@ def sp_playlist_container_mock():
 
 
 @pytest.fixture
-def webapi_search_mock(
-        webapi_album_mock, webapi_artist_mock, webapi_track_mock):
+def web_search_mock(
+        web_album_mock, web_artist_mock, web_track_mock):
     return {
         'albums': {
-            'items': [webapi_album_mock]
+            'items': [web_album_mock]
         },
         'artists': {
-            'items': [webapi_artist_mock]
+            'items': [web_artist_mock]
         },
         'tracks': {
-            'items': [webapi_track_mock, webapi_track_mock]
+            'items': [web_track_mock, web_track_mock]
         }
     }
 
 
 @pytest.fixture
-def webapi_search_mock_large(
-        webapi_album_mock, webapi_artist_mock, webapi_track_mock):
+def web_search_mock_large(
+        web_album_mock, web_artist_mock, web_track_mock):
     return {
         'albums': {
-            'items': [webapi_album_mock] * 10
+            'items': [web_album_mock] * 10
         },
         'artists': {
-            'items': [webapi_artist_mock] * 10
+            'items': [web_artist_mock] * 10
         },
         'tracks': {
-            'items': [webapi_track_mock] * 10
+            'items': [web_track_mock] * 10
         }
     }
 
 
 @pytest.fixture
-def webapi_artist_mock():
+def web_artist_mock():
     return {
         'name': 'ABBA',
         'uri': 'spotify:artist:abba'
@@ -312,7 +312,7 @@ def webapi_artist_mock():
 
 
 @pytest.fixture
-def webapi_album_mock():
+def web_album_mock():
     return {
         'name': 'DEF 456',
         'uri': 'spotify:album:def'
@@ -320,10 +320,10 @@ def webapi_album_mock():
 
 
 @pytest.fixture
-def webapi_track_mock(webapi_artist_mock, webapi_album_mock):
+def web_track_mock(web_artist_mock, web_album_mock):
     return {
-        'album': webapi_album_mock,
-        'artists': [webapi_artist_mock],
+        'album': web_album_mock,
+        'artists': [web_artist_mock],
         'disc_number': 1,
         'duration_ms': 174300,
         'name': 'ABC 123',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,6 +288,22 @@ def webapi_search_mock(
 
 
 @pytest.fixture
+def webapi_search_mock_large(
+        webapi_album_mock, webapi_artist_mock, webapi_track_mock):
+    return {
+        'albums': {
+            'items': [webapi_album_mock] * 10
+        },
+        'artists': {
+            'items': [webapi_artist_mock] * 10
+        },
+        'tracks': {
+            'items': [webapi_track_mock] * 10
+        }
+    }
+
+
+@pytest.fixture
 def webapi_artist_mock():
     return {
         'name': 'ABBA',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,13 +272,48 @@ def sp_playlist_container_mock():
 
 
 @pytest.fixture
-def sp_search_mock(sp_album_mock, sp_artist_mock, sp_track_mock):
-    sp_search = mock.Mock(spec=spotify.Search)
-    sp_search.is_loaded = True
-    sp_search.albums = [sp_album_mock]
-    sp_search.artists = [sp_artist_mock]
-    sp_search.tracks = [sp_track_mock, sp_track_mock]
-    return sp_search
+def webapi_search_mock(
+        webapi_album_mock, webapi_artist_mock, webapi_track_mock):
+    return {
+        'albums': {
+            'items': [webapi_album_mock]
+        },
+        'artists': {
+            'items': [webapi_artist_mock]
+        },
+        'tracks': {
+            'items': [webapi_track_mock, webapi_track_mock]
+        }
+    }
+
+
+@pytest.fixture
+def webapi_artist_mock():
+    return {
+        'name': 'ABBA',
+        'uri': 'spotify:artist:abba'
+    }
+
+
+@pytest.fixture
+def webapi_album_mock():
+    return {
+        'name': 'DEF 456',
+        'uri': 'spotify:album:def'
+    }
+
+
+@pytest.fixture
+def webapi_track_mock(webapi_artist_mock, webapi_album_mock):
+    return {
+        'album': webapi_album_mock,
+        'artists': [webapi_artist_mock],
+        'disc_number': 1,
+        'duration_ms': 174300,
+        'name': 'ABC 123',
+        'track_number': 7,
+        'uri': 'spotify:track:abc',
+    }
 
 
 @pytest.fixture

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -75,10 +75,10 @@ def test_search_when_offline_returns_nothing(session_mock, provider, caplog):
 
 @responses.activate
 def test_search_returns_albums_and_artists_and_tracks(
-        webapi_search_mock, provider, caplog):
+        web_search_mock, provider, caplog):
     responses.add(
         responses.GET, 'https://api.spotify.com/v1/search',
-        body=json.dumps(webapi_search_mock))
+        body=json.dumps(web_search_mock))
 
     result = provider.search({'any': ['ABBA']})
 
@@ -111,14 +111,14 @@ def test_search_returns_albums_and_artists_and_tracks(
 
 @responses.activate
 def test_search_limits_number_of_results(
-        webapi_search_mock_large, provider, config):
+        web_search_mock_large, provider, config):
     config['spotify']['search_album_count'] = 4
     config['spotify']['search_artist_count'] = 5
     config['spotify']['search_track_count'] = 6
 
     responses.add(
         responses.GET, 'https://api.spotify.com/v1/search',
-        body=json.dumps(webapi_search_mock_large))
+        body=json.dumps(web_search_mock_large))
 
     result = provider.search({'any': ['ABBA']})
 
@@ -129,14 +129,14 @@ def test_search_limits_number_of_results(
 
 @responses.activate
 def test_sets_api_limit_to_album_count_when_max(
-        webapi_search_mock_large, provider, config):
+        web_search_mock_large, provider, config):
     config['spotify']['search_album_count'] = 6
     config['spotify']['search_artist_count'] = 2
     config['spotify']['search_track_count'] = 2
 
     responses.add(
         responses.GET, 'https://api.spotify.com/v1/search',
-        body=json.dumps(webapi_search_mock_large))
+        body=json.dumps(web_search_mock_large))
 
     result = provider.search({'any': ['ABBA']})
 
@@ -154,14 +154,14 @@ def test_sets_api_limit_to_album_count_when_max(
 
 @responses.activate
 def test_sets_api_limit_to_artist_count_when_max(
-        webapi_search_mock_large, provider, config):
+        web_search_mock_large, provider, config):
     config['spotify']['search_album_count'] = 2
     config['spotify']['search_artist_count'] = 6
     config['spotify']['search_track_count'] = 2
 
     responses.add(
         responses.GET, 'https://api.spotify.com/v1/search',
-        body=json.dumps(webapi_search_mock_large))
+        body=json.dumps(web_search_mock_large))
 
     result = provider.search({'any': ['ABBA']})
 
@@ -179,14 +179,14 @@ def test_sets_api_limit_to_artist_count_when_max(
 
 @responses.activate
 def test_sets_api_limit_to_track_count_when_max(
-        webapi_search_mock_large, provider, config):
+        web_search_mock_large, provider, config):
     config['spotify']['search_album_count'] = 2
     config['spotify']['search_artist_count'] = 2
     config['spotify']['search_track_count'] = 6
 
     responses.add(
         responses.GET, 'https://api.spotify.com/v1/search',
-        body=json.dumps(webapi_search_mock_large))
+        body=json.dumps(web_search_mock_large))
 
     result = provider.search({'any': ['ABBA']})
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -103,6 +103,87 @@ def test_search_returns_albums_and_artists_and_tracks(
     assert result.tracks[0].uri == 'spotify:track:abc'
 
 
+@responses.activate
+def test_search_limits_number_of_results(
+        webapi_search_mock_large, provider, config):
+    config['spotify']['search_album_count'] = 4
+    config['spotify']['search_artist_count'] = 5
+    config['spotify']['search_track_count'] = 6
+
+    responses.add(
+        responses.GET, 'https://api.spotify.com/v1/search',
+        body=json.dumps(webapi_search_mock_large))
+
+    result = provider.search({'any': ['ABBA']})
+
+    assert len(result.albums) == 4
+    assert len(result.artists) == 5
+    assert len(result.tracks) == 6
+
+
+@responses.activate
+def test_sets_api_limit_to_album_count_when_max(
+        webapi_search_mock_large, provider, config):
+    config['spotify']['search_album_count'] = 6
+    config['spotify']['search_artist_count'] = 2
+    config['spotify']['search_track_count'] = 2
+
+    responses.add(
+        responses.GET, 'https://api.spotify.com/v1/search',
+        body=json.dumps(webapi_search_mock_large))
+
+    result = provider.search({'any': ['ABBA']})
+
+    assert (
+        responses.calls[0].request.url ==
+        'https://api.spotify.com/v1/search?q=%22ABBA%22&'
+        'type=album%2Cartist%2Ctrack&limit=6')
+
+    assert len(result.albums) == 6
+
+
+@responses.activate
+def test_sets_api_limit_to_artist_count_when_max(
+        webapi_search_mock_large, provider, config):
+    config['spotify']['search_album_count'] = 2
+    config['spotify']['search_artist_count'] = 6
+    config['spotify']['search_track_count'] = 2
+
+    responses.add(
+        responses.GET, 'https://api.spotify.com/v1/search',
+        body=json.dumps(webapi_search_mock_large))
+
+    result = provider.search({'any': ['ABBA']})
+
+    assert (
+        responses.calls[0].request.url ==
+        'https://api.spotify.com/v1/search?q=%22ABBA%22&'
+        'type=album%2Cartist%2Ctrack&limit=6')
+
+    assert len(result.artists) == 6
+
+
+@responses.activate
+def test_sets_api_limit_to_track_count_when_max(
+        webapi_search_mock_large, provider, config):
+    config['spotify']['search_album_count'] = 2
+    config['spotify']['search_artist_count'] = 2
+    config['spotify']['search_track_count'] = 6
+
+    responses.add(
+        responses.GET, 'https://api.spotify.com/v1/search',
+        body=json.dumps(webapi_search_mock_large))
+
+    result = provider.search({'any': ['ABBA']})
+
+    assert (
+        responses.calls[0].request.url ==
+        'https://api.spotify.com/v1/search?q=%22ABBA%22&'
+        'type=album%2Cartist%2Ctrack&limit=6')
+
+    assert len(result.tracks) == 6
+
+
 def test_exact_is_ignored(session_mock, sp_track_mock, provider):
     session_mock.get_link.return_value = sp_track_mock.link
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 import json
 
+import re
+
 from mopidy import models
 
 import responses
@@ -81,10 +83,14 @@ def test_search_returns_albums_and_artists_and_tracks(
     result = provider.search({'any': ['ABBA']})
 
     assert len(responses.calls) == 1
-    assert (
-        responses.calls[0].request.url ==
-        'https://api.spotify.com/v1/search?q=%22ABBA%22&'
-        'type=album%2Cartist%2Ctrack&limit=50')
+
+    uri_parts = sorted(re.split('[?&]', responses.calls[0].request.url))
+    assert (uri_parts == [
+        'https://api.spotify.com/v1/search',
+        'limit=50',
+        'q=%22ABBA%22',
+        'type=album%2Cartist%2Ctrack'])
+
     assert responses.calls[0].request.headers['User-Agent'].startswith(
         'Mopidy-Spotify/%s' % mopidy_spotify.__version__)
 
@@ -134,10 +140,14 @@ def test_sets_api_limit_to_album_count_when_max(
 
     result = provider.search({'any': ['ABBA']})
 
-    assert (
-        responses.calls[0].request.url ==
-        'https://api.spotify.com/v1/search?q=%22ABBA%22&'
-        'type=album%2Cartist%2Ctrack&limit=6')
+    assert len(responses.calls) == 1
+
+    uri_parts = sorted(re.split('[?&]', responses.calls[0].request.url))
+    assert (uri_parts == [
+        'https://api.spotify.com/v1/search',
+        'limit=6',
+        'q=%22ABBA%22',
+        'type=album%2Cartist%2Ctrack'])
 
     assert len(result.albums) == 6
 
@@ -155,10 +165,14 @@ def test_sets_api_limit_to_artist_count_when_max(
 
     result = provider.search({'any': ['ABBA']})
 
-    assert (
-        responses.calls[0].request.url ==
-        'https://api.spotify.com/v1/search?q=%22ABBA%22&'
-        'type=album%2Cartist%2Ctrack&limit=6')
+    assert len(responses.calls) == 1
+
+    uri_parts = sorted(re.split('[?&]', responses.calls[0].request.url))
+    assert (uri_parts == [
+        'https://api.spotify.com/v1/search',
+        'limit=6',
+        'q=%22ABBA%22',
+        'type=album%2Cartist%2Ctrack'])
 
     assert len(result.artists) == 6
 
@@ -176,10 +190,14 @@ def test_sets_api_limit_to_track_count_when_max(
 
     result = provider.search({'any': ['ABBA']})
 
-    assert (
-        responses.calls[0].request.url ==
-        'https://api.spotify.com/v1/search?q=%22ABBA%22&'
-        'type=album%2Cartist%2Ctrack&limit=6')
+    assert len(responses.calls) == 1
+
+    uri_parts = sorted(re.split('[?&]', responses.calls[0].request.url))
+    assert (uri_parts == [
+        'https://api.spotify.com/v1/search',
+        'limit=6',
+        'q=%22ABBA%22',
+        'type=album%2Cartist%2Ctrack'])
 
     assert len(result.tracks) == 6
 

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -428,3 +428,38 @@ class TestSpotifySearchQuery(object):
         assert 'album:"Greatest Hits"' in query
         assert 'track:"Dancing Queen"' in query
         assert 'year:1970' in query
+
+
+class TestWebapiToArtist(object):
+
+    def test_successful_translation(self, webapi_artist_mock):
+        artist = translator.webapi_to_artist(webapi_artist_mock)
+
+        assert artist.uri == 'spotify:artist:abba'
+        assert artist.name == 'ABBA'
+
+
+class TestWebapiToAlbum(object):
+
+    def test_successful_translation(self, webapi_album_mock):
+        album = translator.webapi_to_album(webapi_album_mock)
+
+        assert album.uri == 'spotify:album:def'
+        assert album.name == 'DEF 456'
+
+
+class TestWebapiToTrack(object):
+
+    def test_successful_translation(self, webapi_track_mock):
+        track = translator.webapi_to_track(webapi_track_mock)
+
+        assert track.uri == 'spotify:track:abc'
+        assert track.name == 'ABC 123'
+        assert list(track.artists) == [
+            models.Artist(uri='spotify:artist:abba', name='ABBA')]
+        assert track.album == models.Album(
+            uri='spotify:album:def',
+            name='DEF 456')
+        assert track.track_no == 7
+        assert track.disc_no == 1
+        assert track.length == 174300

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -430,28 +430,28 @@ class TestSpotifySearchQuery(object):
         assert 'year:1970' in query
 
 
-class TestWebapiToArtist(object):
+class TestWebToArtist(object):
 
-    def test_successful_translation(self, webapi_artist_mock):
-        artist = translator.webapi_to_artist(webapi_artist_mock)
+    def test_successful_translation(self, web_artist_mock):
+        artist = translator.web_to_artist(web_artist_mock)
 
         assert artist.uri == 'spotify:artist:abba'
         assert artist.name == 'ABBA'
 
 
-class TestWebapiToAlbum(object):
+class TestWebToAlbum(object):
 
-    def test_successful_translation(self, webapi_album_mock):
-        album = translator.webapi_to_album(webapi_album_mock)
+    def test_successful_translation(self, web_album_mock):
+        album = translator.web_to_album(web_album_mock)
 
         assert album.uri == 'spotify:album:def'
         assert album.name == 'DEF 456'
 
 
-class TestWebapiToTrack(object):
+class TestWebToTrack(object):
 
-    def test_successful_translation(self, webapi_track_mock):
-        track = translator.webapi_to_track(webapi_track_mock)
+    def test_successful_translation(self, web_track_mock):
+        track = translator.web_to_track(web_track_mock)
 
         assert track.uri == 'spotify:track:abc'
         assert track.name == 'ABC 123'


### PR DESCRIPTION
This changes search to use the Web API, since search through libspotify doesn't work anymore.

It has some shortcomings, such as not having any artists for album results and returning unavailable tracks, but it's a first step. See the commit messages for details.

I see that the old search is used in distinct as well, but I don't know where that's used from, and haven't looked at that yet. This fixes the normal search at least.

I'm creating the PR against master, because I'm thinking we may want to create a bugfix release for use against the current version of Mopidy. (Should we have a release-2.3 branch?)

Fixes #89.