### PR TITLE
Use Spotifys Web API for distinct

### DIFF
--- a/mopidy_spotify/distinct.py
+++ b/mopidy_spotify/distinct.py
@@ -4,40 +4,41 @@ import logging
 
 import spotify
 
-from mopidy_spotify import translator
+from mopidy_spotify import search
 
 
 logger = logging.getLogger(__name__)
 
 
-def get_distinct(config, session, field, query=None):
+def get_distinct(config, session, requests_session, field, query=None):
     # To make the returned data as interesting as possible, we limit
     # ourselves to data extracted from the user's playlists when no search
     # query is included.
 
-    sp_query = translator.sp_search_query(query) if query else None
-
     if field == 'artist':
-        result = _get_distinct_artists(config, session, sp_query)
+        result = _get_distinct_artists(
+            config, session, requests_session, query)
     elif field == 'albumartist':
-        result = _get_distinct_albumartists(config, session, sp_query)
+        result = _get_distinct_albumartists(
+            config, session, requests_session, query)
     elif field == 'album':
-        result = _get_distinct_albums(config, session, sp_query)
+        result = _get_distinct_albums(
+            config, session, requests_session, query)
     elif field == 'date':
-        result = _get_distinct_dates(config, session, sp_query)
+        result = _get_distinct_dates(
+            config, session, requests_session, query)
     else:
         result = set()
 
     return result - {None}
 
 
-def _get_distinct_artists(config, session, sp_query):
-    logger.debug('Getting distinct artists: %s', sp_query)
-    if sp_query:
-        sp_search = _get_sp_search(config, session, sp_query, artist=True)
-        if sp_search is None:
-            return set()
-        return {artist.name for artist in sp_search.artists}
+def _get_distinct_artists(config, session, requests_session, query):
+    logger.debug('Getting distinct artists: %s', query)
+    if query:
+        search_result = _get_search(
+            config, session, requests_session, query, artist=True)
+        return {artist.name for artist in search_result.artists}
     else:
         return {
             artist.name
@@ -45,17 +46,17 @@ def _get_distinct_artists(config, session, sp_query):
             for artist in track.artists}
 
 
-def _get_distinct_albumartists(config, session, sp_query):
+def _get_distinct_albumartists(config, session, requests_session, query):
     logger.debug(
-        'Getting distinct albumartists: %s', sp_query)
-    if sp_query:
-        sp_search = _get_sp_search(config, session, sp_query, album=True)
-        if sp_search is None:
-            return set()
+        'Getting distinct albumartists: %s', query)
+    if query:
+        search_result = _get_search(
+            config, session, requests_session, query, album=True)
         return {
-            album.artist.name
-            for album in sp_search.albums
-            if album.artist}
+            artist.name
+            for album in search_result.albums
+            for artist in album.artists
+            if album.artists}
     else:
         return {
             track.album.artist.name
@@ -63,13 +64,12 @@ def _get_distinct_albumartists(config, session, sp_query):
             if track.album and track.album.artist}
 
 
-def _get_distinct_albums(config, session, sp_query):
-    logger.debug('Getting distinct albums: %s', sp_query)
-    if sp_query:
-        sp_search = _get_sp_search(config, session, sp_query, album=True)
-        if sp_search is None:
-            return set()
-        return {album.name for album in sp_search.albums}
+def _get_distinct_albums(config, session, requests_session, query):
+    logger.debug('Getting distinct albums: %s', query)
+    if query:
+        search_result = _get_search(
+            config, session, requests_session, query, album=True)
+        return {album.name for album in search_result.albums}
     else:
         return {
             track.album.name
@@ -77,16 +77,15 @@ def _get_distinct_albums(config, session, sp_query):
             if track.album}
 
 
-def _get_distinct_dates(config, session, sp_query):
-    logger.debug('Getting distinct album years: %s', sp_query)
-    if sp_query:
-        sp_search = _get_sp_search(config, session, sp_query, album=True)
-        if sp_search is None:
-            return set()
+def _get_distinct_dates(config, session, requests_session, query):
+    logger.debug('Getting distinct album years: %s', query)
+    if query:
+        search_result = _get_search(
+            config, session, requests_session, query, album=True)
         return {
-            '%s' % album.year
-            for album in sp_search.albums
-            if album.year not in (None, 0)}
+            album.date
+            for album in search_result.albums
+            if album.date not in (None, '0')}
     else:
         return {
             '%s' % track.album.year
@@ -94,20 +93,11 @@ def _get_distinct_dates(config, session, sp_query):
             if track.album and track.album.year not in (None, 0)}
 
 
-def _get_sp_search(
-        config, session, sp_query, album=False, artist=False, track=False):
+def _get_search(
+        config, session, requests_session, query,
+        album=False, artist=False, track=False):
 
-    if session.connection.state is not spotify.ConnectionState.LOGGED_IN:
-        logger.info('Spotify search aborted: Spotify is offline')
-        return None
-
-    sp_search = session.search(
-        sp_query,
-        album_count=config['search_album_count'] if album else 0,
-        artist_count=config['search_artist_count'] if artist else 0,
-        track_count=config['search_track_count'] if track else 0)
-    sp_search.load()
-    return sp_search
+    return search.search(config, session, requests_session, query)
 
 
 def _get_playlist_tracks(config, session):

--- a/mopidy_spotify/distinct.py
+++ b/mopidy_spotify/distinct.py
@@ -97,7 +97,16 @@ def _get_search(
         config, session, requests_session, query,
         album=False, artist=False, track=False):
 
-    return search.search(config, session, requests_session, query)
+    types = []
+    if album:
+        types.append('album')
+    if artist:
+        types.append('artist')
+    if track:
+        types.append('track')
+
+    return search.search(
+        config, session, requests_session, query, types=types)
 
 
 def _get_playlist_tracks(config, session):

--- a/mopidy_spotify/library.py
+++ b/mopidy_spotify/library.py
@@ -28,7 +28,8 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
 
     def get_distinct(self, field, query=None):
         return distinct.get_distinct(
-            self._config, self._backend._session, field, query)
+            self._config, self._backend._session, self._requests_session,
+            field, query)
 
     def get_images(self, uris):
         return images.get_images(self._requests_session, uris)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import mock
 
-from mopidy import backend as backend_api
+from mopidy import backend as backend_api, models
 
 import pytest
 
@@ -330,6 +330,22 @@ def web_track_mock(web_artist_mock, web_album_mock):
         'track_number': 7,
         'uri': 'spotify:track:abc',
     }
+
+
+@pytest.fixture
+def mopidy_artist_mock():
+    return models.Artist(
+        name='ABBA',
+        uri='spotify:artist:abba')
+
+
+@pytest.fixture
+def mopidy_album_mock(mopidy_artist_mock):
+    return models.Album(
+        artists=[mopidy_artist_mock],
+        date='2001',
+        name='DEF 456',
+        uri='spotify:album:def')
 
 
 @pytest.fixture

--- a/tests/test_distinct.py
+++ b/tests/test_distinct.py
@@ -69,31 +69,36 @@ def test_get_distinct_without_query_returns_nothing_when_playlists_disabled(
     assert provider.get_distinct(field) == set()
 
 
-@pytest.mark.parametrize('field,query,expected', [
+@pytest.mark.parametrize('field,query,expected,types', [
     (
         'artist',
         {'album': ['Foo']},
         {'ABBA'},
+        ['artist'],
     ),
     (
         'albumartist',
         {'album': ['Foo']},
         {'ABBA'},
+        ['album'],
     ),
     (
         'album',
         {'artist': ['Bar']},
         {'DEF 456'},
+        ['album'],
     ),
     (
         'date',
         {'artist': ['Bar']},
         {'2001'},
+        ['album'],
     ),
 ])
 def test_get_distinct_with_query(
-        search_mock, provider, config, session_mock, field, query, expected):
+        search_mock, provider, config, session_mock,
+        field, query, expected, types):
 
     assert provider.get_distinct(field, query) == expected
     search_mock.search.assert_called_once_with(
-        mock.ANY, mock.ANY, mock.ANY, query)
+        mock.ANY, mock.ANY, mock.ANY, query, types=types)

--- a/tests/test_distinct.py
+++ b/tests/test_distinct.py
@@ -1,8 +1,12 @@
 from __future__ import unicode_literals
 
+import mock
+
+from mopidy import models
+
 import pytest
 
-import spotify
+from mopidy_spotify import distinct, search
 
 
 @pytest.fixture
@@ -19,18 +23,14 @@ def session_mock_with_playlists(
     return session_mock
 
 
-@pytest.fixture
-def session_mock_with_search(
-        session_mock,
-        sp_album_mock, sp_unloaded_album_mock,
-        sp_artist_mock, sp_unloaded_artist_mock):
-
-    session_mock.connection.state = spotify.ConnectionState.LOGGED_IN
-    session_mock.search.return_value.albums = [
-        sp_album_mock, sp_unloaded_album_mock]
-    session_mock.search.return_value.artists = [
-        sp_artist_mock, sp_unloaded_artist_mock]
-    return session_mock
+@pytest.yield_fixture
+def search_mock(mopidy_album_mock, mopidy_artist_mock):
+    patcher = mock.patch.object(distinct, 'search', spec=search)
+    search_mock = patcher.start()
+    search_mock.search.return_value = models.SearchResult(
+        albums=[mopidy_album_mock], artists=[mopidy_artist_mock])
+    yield search_mock
+    patcher.stop()
 
 
 @pytest.mark.parametrize('field', [
@@ -69,49 +69,31 @@ def test_get_distinct_without_query_returns_nothing_when_playlists_disabled(
     assert provider.get_distinct(field) == set()
 
 
-@pytest.mark.parametrize('field,query,expected,search_args,search_kwargs', [
+@pytest.mark.parametrize('field,query,expected', [
     (
         'artist',
         {'album': ['Foo']},
         {'ABBA'},
-        ('album:"Foo"',),
-        dict(album_count=0, artist_count=10, track_count=0),
     ),
     (
         'albumartist',
         {'album': ['Foo']},
         {'ABBA'},
-        ('album:"Foo"',),
-        dict(album_count=20, artist_count=0, track_count=0),
     ),
     (
         'album',
         {'artist': ['Bar']},
         {'DEF 456'},
-        ('artist:"Bar"',),
-        dict(album_count=20, artist_count=0, track_count=0),
     ),
     (
         'date',
         {'artist': ['Bar']},
         {'2001'},
-        ('artist:"Bar"',),
-        dict(album_count=20, artist_count=0, track_count=0),
     ),
 ])
 def test_get_distinct_with_query(
-        session_mock_with_search, provider,
-        field, query, expected, search_args, search_kwargs):
+        search_mock, provider, config, session_mock, field, query, expected):
 
     assert provider.get_distinct(field, query) == expected
-    session_mock_with_search.search.assert_called_once_with(
-        *search_args, **search_kwargs)
-
-
-def test_get_distinct_with_query_when_offline(
-        session_mock_with_search, provider):
-
-    session_mock_with_search.connection.state = spotify.ConnectionState.OFFLINE
-
-    assert provider.get_distinct('artist', {'album': ['Foo']}) == set()
-    assert session_mock_with_search.search.return_value.load.call_count == 0
+    search_mock.search.assert_called_once_with(
+        mock.ANY, mock.ANY, mock.ANY, query)


### PR DESCRIPTION
Previously, distinct searched directly with pyspotify when given a query argument. This changes it to use the internal search method, which has been changed to using Spotifys Web API.