### PR TITLE
Add config parameter to specify the market the search is run against

### DIFF
--- a/mopidy_spotify/__init__.py
+++ b/mopidy_spotify/__init__.py
@@ -42,6 +42,8 @@ class Extension(ext.Extension):
         schema['search_track_count'] = config.Integer(minimum=0, maximum=200)
 
         schema['toplist_countries'] = config.List(optional=True)
+		
+		schema['user_market'] = config.String()
 
         return schema
 

--- a/mopidy_spotify/ext.conf
+++ b/mopidy_spotify/ext.conf
@@ -13,3 +13,4 @@ search_album_count = 20
 search_artist_count = 10
 search_track_count = 50
 toplist_countries =
+user_market =

--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -14,6 +14,7 @@ from mopidy_spotify import lookup, translator
 
 _API_BASE_URI = 'https://api.spotify.com/v1/search'
 _SEARCH_TYPES = ['album', 'artist', 'track']
+_USER_MARKET = config['user_market']
 
 logger = logging.getLogger(__name__)
 
@@ -56,10 +57,16 @@ def search(config, session, requests_session,
         search_count = 50
 
     try:
-        response = requests_session.get(_API_BASE_URI, params={
+	
+		params={
             'q': sp_query,
             'limit': search_count,
-            'type': ','.join(types)})
+            'type': ','.join(types)}
+			
+		if _USER_MARKET:
+			params['market'] = _USER_MARKET
+	
+        response = requests_session.get(_API_BASE_URI, params)
     except requests.RequestException as exc:
         logger.debug('Fetching %s failed: %s', uri, exc)
         return models.SearchResult(uri=uri)


### PR DESCRIPTION
This should bypass the situation when the user is not on US (default) market and the intended results are not available on US market. Should also then fix the issue if the results are only available on US market, but not on users market making the track unplayable.
