### PR TITLE
search: Include the artists for each album in the search results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v3.1.0 (UNRELEASED)
+-------------------
+
+Feature release.
+
+ - Include the artists of each album in the search results. (PR: #118)
+
 v3.0.0 (2016-02-15)
 -------------------
 

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -239,7 +239,13 @@ def web_to_artist(web_artist):
 
 
 def web_to_album(web_album):
-    return models.Album(uri=web_album['uri'], name=web_album['name'])
+    artists = [
+        web_to_artist(web_artist) for web_artist in web_album['artists']]
+
+    return models.Album(
+        uri=web_album['uri'],
+        name=web_album['name'],
+        artists=artists)
 
 
 def web_to_track(web_track):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -312,10 +312,11 @@ def web_artist_mock():
 
 
 @pytest.fixture
-def web_album_mock():
+def web_album_mock(web_artist_mock):
     return {
         'name': 'DEF 456',
-        'uri': 'spotify:album:def'
+        'uri': 'spotify:album:def',
+        'artists': [web_artist_mock]
     }
 
 

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -444,8 +444,11 @@ class TestWebToAlbum(object):
     def test_successful_translation(self, web_album_mock):
         album = translator.web_to_album(web_album_mock)
 
+        artists = [models.Artist(uri='spotify:artist:abba', name='ABBA')]
+
         assert album.uri == 'spotify:album:def'
         assert album.name == 'DEF 456'
+        assert list(album.artists) == artists
 
 
 class TestWebToTrack(object):
@@ -453,13 +456,15 @@ class TestWebToTrack(object):
     def test_successful_translation(self, web_track_mock):
         track = translator.web_to_track(web_track_mock)
 
+        artists = [models.Artist(uri='spotify:artist:abba', name='ABBA')]
+
         assert track.uri == 'spotify:track:abc'
         assert track.name == 'ABC 123'
-        assert list(track.artists) == [
-            models.Artist(uri='spotify:artist:abba', name='ABBA')]
+        assert list(track.artists) == artists
         assert track.album == models.Album(
             uri='spotify:album:def',
-            name='DEF 456')
+            name='DEF 456',
+            artists=artists)
         assert track.track_no == 7
         assert track.disc_no == 1
         assert track.length == 174300


### PR DESCRIPTION
Spotifys Web API now includes the artists of each album in the search
results.