### PR TITLE
search: Don't quote the any field of search queries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v3.x.x (UNRELEASED)
+-------------------
+
+- Don't quote the any field of search queries. This allows you do get non-exact
+  matches. Exact matches can still be done by including quotes ("") in the
+  search query yourself. (PR: #119)
+
 v3.0.0 (2016-02-15)
 -------------------
 

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -218,7 +218,7 @@ def sp_search_query(query):
                 if value is not None:
                     result.append('%s:%d' % (field, value))
             elif field == 'any':
-                result.append('"%s"' % value)
+                result.append('%s' % value)
             else:
                 result.append('%s:"%s"' % (field, value))
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -72,7 +72,7 @@ def test_search_when_offline_returns_nothing(session_mock, provider, caplog):
     assert 'Spotify search aborted: Spotify is offline' in caplog.text()
 
     assert isinstance(result, models.SearchResult)
-    assert result.uri == 'spotify:search:%22ABBA%22'
+    assert result.uri == 'spotify:search:ABBA'
     assert len(result.tracks) == 0
 
 
@@ -91,16 +91,16 @@ def test_search_returns_albums_and_artists_and_tracks(
     assert (uri_parts == [
         'https://api.spotify.com/v1/search',
         'limit=50',
-        'q=%22ABBA%22',
+        'q=ABBA',
         'type=album%2Cartist%2Ctrack'])
 
     assert responses.calls[0].request.headers['User-Agent'].startswith(
         'Mopidy-Spotify/%s' % mopidy_spotify.__version__)
 
-    assert 'Searching Spotify for: "ABBA"' in caplog.text()
+    assert 'Searching Spotify for: ABBA' in caplog.text()
 
     assert isinstance(result, models.SearchResult)
-    assert result.uri == 'spotify:search:%22ABBA%22'
+    assert result.uri == 'spotify:search:ABBA'
 
     assert len(result.albums) == 1
     assert result.albums[0].uri == 'spotify:album:def'
@@ -149,7 +149,7 @@ def test_sets_api_limit_to_album_count_when_max(
     assert (uri_parts == [
         'https://api.spotify.com/v1/search',
         'limit=6',
-        'q=%22ABBA%22',
+        'q=ABBA',
         'type=album%2Cartist%2Ctrack'])
 
     assert len(result.albums) == 6
@@ -174,7 +174,7 @@ def test_sets_api_limit_to_artist_count_when_max(
     assert (uri_parts == [
         'https://api.spotify.com/v1/search',
         'limit=6',
-        'q=%22ABBA%22',
+        'q=ABBA',
         'type=album%2Cartist%2Ctrack'])
 
     assert len(result.artists) == 6
@@ -199,7 +199,7 @@ def test_sets_api_limit_to_track_count_when_max(
     assert (uri_parts == [
         'https://api.spotify.com/v1/search',
         'limit=6',
-        'q=%22ABBA%22',
+        'q=ABBA',
         'type=album%2Cartist%2Ctrack'])
 
     assert len(result.tracks) == 6
@@ -222,7 +222,7 @@ def test_sets_types_parameter(
     assert (uri_parts == [
         'https://api.spotify.com/v1/search',
         'limit=50',
-        'q=%22ABBA%22',
+        'q=ABBA',
         'type=album%2Cartist'])
 
 
@@ -236,7 +236,7 @@ def test_handles_empty_response(
     result = provider.search({'any': ['ABBA']})
 
     assert isinstance(result, models.SearchResult)
-    assert result.uri == 'spotify:search:%22ABBA%22'
+    assert result.uri == 'spotify:search:ABBA'
 
     assert len(result.albums) == 0
     assert len(result.artists) == 0

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -364,7 +364,7 @@ class TestSpotifySearchQuery(object):
     def test_any_maps_to_no_field(self):
         query = translator.sp_search_query({'any': ['ABC', 'DEF']})
 
-        assert query == '"ABC" "DEF"'
+        assert query == 'ABC DEF'
 
     def test_artist_maps_to_artist(self):
         query = translator.sp_search_query({'artist': ['ABBA', 'ACDC']})
@@ -422,8 +422,8 @@ class TestSpotifySearchQuery(object):
             'year': ['1970-01-02'],
         })
 
-        assert '"ABC"' in query
-        assert '"DEF"' in query
+        assert 'ABC' in query
+        assert 'DEF' in query
         assert 'artist:"ABBA"' in query
         assert 'album:"Greatest Hits"' in query
         assert 'track:"Dancing Queen"' in query


### PR DESCRIPTION
If you include quotes around the query, you only get exact matches. From
the API documentation:

    Keywords will be matched in any order unless surrounded by double
    quotation marks: q=roadhouse&20blues will match both "Blues
    Roadhouse" and "Roadhouse of the Blues" while q="roadhouse&20blues"
    will match "My Roadhouse Blues" but not "Roadhouse of the Blues".

This means that non-exact matches previously wasn't possible. I think we
should default to non-exact matches. With this, exact matches are still
possible by including "" around the query yourself.

With the non-exact match you can also use different query types at the
same time in the any field, e.g. artist and track name. This is not
possible with the exact match.

The other fields still use quotes for now. If you don't include quotes,
only the first word will be for that field, while the rest will be
treated like the words in the any field. It seems like if you want
multiple words for a specific field, you need to include the field name
in front of each word, e.g.: track:roadhouse%20track:blues