### PR TITLE
Include adding the apt.mopidy.com's GPG key and APT repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,8 @@ Installation
 Debian/Ubuntu/Raspbian: Install the ``mopidy-spotify`` package from
 `apt.mopidy.com <http://apt.mopidy.com/>`_::
 
+    wget -q -O - https://apt.mopidy.com/mopidy.gpg | sudo apt-key add -
+    sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/jessie.list
     sudo apt-get install mopidy-spotify
 
 Arch Linux: Install the ``mopidy-spotify`` package from


### PR DESCRIPTION
If users don't follow the instructions on https://docs.mopidy.com/en/latest/installation/debian/ and just run: sudo-apt-get install mopidy-spotify, then they will receive the following error: "Unable to locate package mopidy-spotify".

If you would prefer, I could change the line with the link to https://docs.mopidy.com/en/latest/installation/debian/ to include something like "Be sure to visit this URL to ensure you install the GPG key and APT repo before installing mopidy-spotify.