### PR TITLE
Fix missing / unavailable tracks in search results

### DIFF
--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -56,6 +56,7 @@ def search(config, session, web_client,
     result = web_client.get(_API_BASE_URI, params={
         'q': sp_query,
         'limit': search_count,
+        'market': session.user_country,
         'type': ','.join(types)})
 
     albums = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -366,6 +366,7 @@ def session_mock():
     sp_session_mock = mock.Mock(spec=spotify.Session)
     sp_session_mock.connection.state = spotify.ConnectionState.LOGGED_IN
     sp_session_mock.playlist_container = []
+    sp_session_mock.user_country = 'GB'
     return sp_session_mock
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -77,6 +77,7 @@ def test_search_returns_albums_and_artists_and_tracks(
         params={
             'q': '"ABBA"',
             'limit': 50,
+            'market': 'GB',
             'type': 'album,artist,track'})
 
     assert 'Searching Spotify for: "ABBA"' in caplog.text()
@@ -124,6 +125,7 @@ def test_sets_api_limit_to_album_count_when_max(
         params={
             'q': '"ABBA"',
             'limit': 6,
+            'market': 'GB',
             'type': 'album,artist,track'})
 
     assert len(result.albums) == 6
@@ -144,6 +146,7 @@ def test_sets_api_limit_to_artist_count_when_max(
         params={
             'q': '"ABBA"',
             'limit': 6,
+            'market': 'GB',
             'type': 'album,artist,track'})
 
     assert len(result.artists) == 6
@@ -164,6 +167,7 @@ def test_sets_api_limit_to_track_count_when_max(
         params={
             'q': '"ABBA"',
             'limit': 6,
+            'market': 'GB',
             'type': 'album,artist,track'})
 
     assert len(result.tracks) == 6
@@ -183,7 +187,24 @@ def test_sets_types_parameter(
         params={
             'q': '"ABBA"',
             'limit': 50,
+            'market': 'GB',
             'type': 'album,artist'})
+
+
+def test_sets_market_parameter_from_user_country(
+        web_client_mock, web_search_mock_large, provider, session_mock):
+    session_mock.user_country = 'SE'
+    web_client_mock.get.return_value = web_search_mock_large
+
+    provider.search({'any': ['ABBA']})
+
+    web_client_mock.get.assert_called_once_with(
+        'https://api.spotify.com/v1/search',
+        params={
+            'q': '"ABBA"',
+            'limit': 50,
+            'market': 'SE',
+            'type': 'album,artist,track'})
 
 
 def test_handles_empty_response(web_client_mock, provider):


### PR DESCRIPTION
This fixes #97 by setting the market parameter when doing searches using the Web API.

We don't currently set the parameter and it defaults to 'US' (https://github.com/spotify/web-api/issues/194). Depending on the logged in user's country, this may result in missing or unavailable tracks being returned. For example "The black box revelation" as reported in https://github.com/mopidy/mopidy-spotify/issues/106.

I appreciate that considering https://github.com/mopidy/mopidy-spotify/issues/130, this might not see the light of day, but at least this should remind us to set it as part of those future changes.