### PR TITLE
Update README in case Spotify website breaks on device password

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,11 @@ Dependencies
 - A non-Facebook Spotify username and password. If you created your account
   through Facebook you'll need to create a "device password" to be able to use
   Mopidy-Spotify. Go to http://www.spotify.com/account/set-device-password/,
-  login with your Facebook account, and follow the instructions.
+  login with your Facebook account, and follow the instructions. However,
+  sometimes that process can fail for users with Facebook logins, in which case
+  you can create an app-specific password on Facebook by going to facebook.com >
+  Settings > Security > App passwords > Generate app passwords, and generate one
+  to use with Mopidy-Spotify.
 
 - ``libspotify`` >= 12, < 13. The official C library from the `Spotify
   developer site <https://developer.spotify.com/technologies/libspotify/>`_.


### PR DESCRIPTION
I had an issue when creating a device-specific password, because the Spotify website kept crashing. I suspect it's because I have a facebook-only login, and I suspect I'm not alone on this one. I managed to get everything working by following the steps outlined in the updated text.