### PR TITLE
OAuth support for accessing Web API endpoints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,11 +73,15 @@ Configuration
 =============
 
 Before starting Mopidy, you must add your Spotify Premium username and password
-to your Mopidy configuration file::
+to your Mopidy configuration file and also visit 
+https://www.mopidy.com/authenticate/#spotify to authorize this extension against
+your Spotify account::
 
     [spotify]
     username = alice
     password = secret
+    client_id = ... client_id value you got from mopidy.com ...
+    client_secret = ... client_secret value you got from mopidy.com ...
 
 The following configuration values are available:
 
@@ -87,6 +91,10 @@ The following configuration values are available:
 - ``spotify/username``: Your Spotify Premium username. You *must* provide this.
 
 - ``spotify/password``: Your Spotify Premium password. You *must* provide this.
+
+- ``spotify/client_id``: Your Spotify application client id. You *must* provide this.
+
+- ``spotify/client_secret``: Your Spotify application secret key. You *must* provide this.
 
 - ``spotify/bitrate``: Audio bitrate in kbps. ``96``, ``160``, or ``320``.
   Defaults to ``160``.

--- a/mopidy_spotify/__init__.py
+++ b/mopidy_spotify/__init__.py
@@ -43,6 +43,9 @@ class Extension(ext.Extension):
 
         schema['toplist_countries'] = config.List(optional=True)
 
+        schema['client_id'] = config.String()
+        schema['client_secret'] = config.Secret()
+
         return schema
 
     def setup(self, registry):

--- a/mopidy_spotify/backend.py
+++ b/mopidy_spotify/backend.py
@@ -10,7 +10,7 @@ import pykka
 
 import spotify
 
-from mopidy_spotify import Extension, library, playback, playlists
+from mopidy_spotify import Extension, library, playback, playlists, web
 
 
 logger = logging.getLogger(__name__)
@@ -38,6 +38,7 @@ class SpotifyBackend(pykka.ThreadingActor, backend.Backend):
         self._session = None
         self._event_loop = None
         self._bitrate = None
+        self._web_client = None
 
         self.library = library.SpotifyLibraryProvider(backend=self)
         self.playback = playback.SpotifyPlaybackProvider(
@@ -58,6 +59,12 @@ class SpotifyBackend(pykka.ThreadingActor, backend.Backend):
         self._session.login(
             self._config['spotify']['username'],
             self._config['spotify']['password'])
+
+        self._web_client = web.OAuthClient(
+            refresh_url='https://auth.mopidy.com/spotify/token',
+            client_id=self._config['spotify']['client_id'],
+            client_secret=self._config['spotify']['client_secret'],
+            proxy_config=self._config['proxy'])
 
     def on_stop(self):
         logger.debug('Logging out of Spotify')

--- a/mopidy_spotify/distinct.py
+++ b/mopidy_spotify/distinct.py
@@ -10,34 +10,34 @@ from mopidy_spotify import search
 logger = logging.getLogger(__name__)
 
 
-def get_distinct(config, session, requests_session, field, query=None):
+def get_distinct(config, session, web_client, field, query=None):
     # To make the returned data as interesting as possible, we limit
     # ourselves to data extracted from the user's playlists when no search
     # query is included.
 
     if field == 'artist':
         result = _get_distinct_artists(
-            config, session, requests_session, query)
+            config, session, web_client, query)
     elif field == 'albumartist':
         result = _get_distinct_albumartists(
-            config, session, requests_session, query)
+            config, session, web_client, query)
     elif field == 'album':
         result = _get_distinct_albums(
-            config, session, requests_session, query)
+            config, session, web_client, query)
     elif field == 'date':
         result = _get_distinct_dates(
-            config, session, requests_session, query)
+            config, session, web_client, query)
     else:
         result = set()
 
     return result - {None}
 
 
-def _get_distinct_artists(config, session, requests_session, query):
+def _get_distinct_artists(config, session, web_client, query):
     logger.debug('Getting distinct artists: %s', query)
     if query:
         search_result = _get_search(
-            config, session, requests_session, query, artist=True)
+            config, session, web_client, query, artist=True)
         return {artist.name for artist in search_result.artists}
     else:
         return {
@@ -46,12 +46,12 @@ def _get_distinct_artists(config, session, requests_session, query):
             for artist in track.artists}
 
 
-def _get_distinct_albumartists(config, session, requests_session, query):
+def _get_distinct_albumartists(config, session, web_client, query):
     logger.debug(
         'Getting distinct albumartists: %s', query)
     if query:
         search_result = _get_search(
-            config, session, requests_session, query, album=True)
+            config, session, web_client, query, album=True)
         return {
             artist.name
             for album in search_result.albums
@@ -64,11 +64,11 @@ def _get_distinct_albumartists(config, session, requests_session, query):
             if track.album and track.album.artist}
 
 
-def _get_distinct_albums(config, session, requests_session, query):
+def _get_distinct_albums(config, session, web_client, query):
     logger.debug('Getting distinct albums: %s', query)
     if query:
         search_result = _get_search(
-            config, session, requests_session, query, album=True)
+            config, session, web_client, query, album=True)
         return {album.name for album in search_result.albums}
     else:
         return {
@@ -77,11 +77,11 @@ def _get_distinct_albums(config, session, requests_session, query):
             if track.album}
 
 
-def _get_distinct_dates(config, session, requests_session, query):
+def _get_distinct_dates(config, session, web_client, query):
     logger.debug('Getting distinct album years: %s', query)
     if query:
         search_result = _get_search(
-            config, session, requests_session, query, album=True)
+            config, session, web_client, query, album=True)
         return {
             album.date
             for album in search_result.albums
@@ -94,7 +94,7 @@ def _get_distinct_dates(config, session, requests_session, query):
 
 
 def _get_search(
-        config, session, requests_session, query,
+        config, session, web_client, query,
         album=False, artist=False, track=False):
 
     types = []
@@ -106,7 +106,7 @@ def _get_search(
         types.append('track')
 
     return search.search(
-        config, session, requests_session, query, types=types)
+        config, session, web_client, query, types=types)
 
 
 def _get_playlist_tracks(config, session):

--- a/mopidy_spotify/ext.conf
+++ b/mopidy_spotify/ext.conf
@@ -13,3 +13,5 @@ search_album_count = 20
 search_artist_count = 10
 search_track_count = 50
 toplist_countries =
+client_id =
+client_secret =

--- a/mopidy_spotify/images.py
+++ b/mopidy_spotify/images.py
@@ -23,7 +23,7 @@ _cache = {}  # (type, id) -> [Image(), ...]
 logger = logging.getLogger(__name__)
 
 
-def get_images(requests_session, uris):
+def get_images(web_client, uris):
     result = {}
     uri_type_getter = operator.itemgetter('type')
     uris = sorted((_parse_uri(u) for u in uris), key=uri_type_getter)
@@ -36,9 +36,9 @@ def get_images(requests_session, uris):
                 batch.append(uri)
                 if len(batch) >= _API_MAX_IDS_PER_REQUEST:
                     result.update(
-                        _process_uris(requests_session, uri_type, batch))
+                        _process_uris(web_client, uri_type, batch))
                     batch = []
-        result.update(_process_uris(requests_session, uri_type, batch))
+        result.update(_process_uris(web_client, uri_type, batch))
     return result
 
 
@@ -59,7 +59,7 @@ def _parse_uri(uri):
     raise ValueError('Could not parse %r as a Spotify URI' % uri)
 
 
-def _process_uris(requests_session, uri_type, uris):
+def _process_uris(web_client, uri_type, uris):
     result = {}
     ids = [u['id'] for u in uris]
     ids_to_uris = {u['id']: u for u in uris}
@@ -70,7 +70,7 @@ def _process_uris(requests_session, uri_type, uris):
     lookup_uri = _API_BASE_URI % (uri_type, ','.join(ids))
 
     try:
-        response = requests_session.get(lookup_uri)
+        response = web_client.get(lookup_uri)
     except requests.RequestException as exc:
         logger.debug('Fetching %s failed: %s', lookup_uri, exc)
         return result

--- a/mopidy_spotify/images.py
+++ b/mopidy_spotify/images.py
@@ -7,8 +7,6 @@ import urlparse
 
 from mopidy import models
 
-import requests
-
 
 # NOTE: This module is independent of libspotify and built using the Spotify
 # Web APIs. As such it does not tie in with any of the regular code used
@@ -69,17 +67,7 @@ def _process_uris(web_client, uri_type, uris):
 
     lookup_uri = _API_BASE_URI % (uri_type, ','.join(ids))
 
-    try:
-        response = web_client.get(lookup_uri)
-    except requests.RequestException as exc:
-        logger.debug('Fetching %s failed: %s', lookup_uri, exc)
-        return result
-
-    try:
-        data = response.json()
-    except ValueError as exc:
-        logger.debug('JSON decoding failed for %s: %s', lookup_uri, exc)
-        return result
+    data = web_client.get(lookup_uri)
 
     for item in data.get(uri_type + 's', []):
         if not item:

--- a/mopidy_spotify/library.py
+++ b/mopidy_spotify/library.py
@@ -4,10 +4,7 @@ import logging
 
 from mopidy import backend
 
-# Workaround https://github.com/public/flake8-import-order/issues/49:
-from mopidy_spotify import Extension
-from mopidy_spotify import (
-    __version__, browse, distinct, images, lookup, search, utils)
+from mopidy_spotify import browse, distinct, images, lookup, search
 
 
 logger = logging.getLogger(__name__)
@@ -19,25 +16,22 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
     def __init__(self, backend):
         self._backend = backend
         self._config = backend._config['spotify']
-        self._requests_session = utils.get_requests_session(
-            proxy_config=backend._config['proxy'],
-            user_agent='%s/%s' % (Extension.dist_name, __version__))
 
     def browse(self, uri):
         return browse.browse(self._config, self._backend._session, uri)
 
     def get_distinct(self, field, query=None):
         return distinct.get_distinct(
-            self._config, self._backend._session, self._requests_session,
+            self._config, self._backend._session, self._backend._web_client,
             field, query)
 
     def get_images(self, uris):
-        return images.get_images(self._requests_session, uris)
+        return images.get_images(self._backend._web_client, uris)
 
     def lookup(self, uri):
         return lookup.lookup(self._config, self._backend._session, uri)
 
     def search(self, query=None, uris=None, exact=False):
         return search.search(
-            self._config, self._backend._session, self._requests_session,
+            self._config, self._backend._session, self._backend._web_client,
             query, uris, exact)

--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -5,8 +5,6 @@ import urllib
 
 from mopidy import models
 
-import requests
-
 import spotify
 
 from mopidy_spotify import lookup, translator
@@ -55,20 +53,10 @@ def search(config, session, web_client,
             'to at most 50.')
         search_count = 50
 
-    try:
-        response = web_client.get(_API_BASE_URI, params={
-            'q': sp_query,
-            'limit': search_count,
-            'type': ','.join(types)})
-    except requests.RequestException as exc:
-        logger.debug('Fetching %s failed: %s', uri, exc)
-        return models.SearchResult(uri=uri)
-
-    try:
-        result = response.json()
-    except ValueError as exc:
-        logger.debug('JSON decoding failed for %s: %s', uri, exc)
-        return models.SearchResult(uri=uri)
+    result = web_client.get(_API_BASE_URI, params={
+        'q': sp_query,
+        'limit': search_count,
+        'type': ','.join(types)})
 
     albums = [
         translator.web_to_album(web_album) for web_album in

--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -18,7 +18,7 @@ _SEARCH_TYPES = ['album', 'artist', 'track']
 logger = logging.getLogger(__name__)
 
 
-def search(config, session, requests_session,
+def search(config, session, web_client,
            query=None, uris=None, exact=False, types=_SEARCH_TYPES):
     # TODO Respect `uris` argument
     # TODO Support `exact` search
@@ -56,7 +56,7 @@ def search(config, session, requests_session,
         search_count = 50
 
     try:
-        response = requests_session.get(_API_BASE_URI, params={
+        response = web_client.get(_API_BASE_URI, params={
             'q': sp_query,
             'limit': search_count,
             'type': ','.join(types)})

--- a/mopidy_spotify/utils.py
+++ b/mopidy_spotify/utils.py
@@ -8,12 +8,15 @@ from mopidy import httpclient
 
 import requests
 
+from mopidy_spotify import Extension, __version__
+
 
 logger = logging.getLogger(__name__)
 TRACE = logging.getLevelName('TRACE')
 
 
-def get_requests_session(proxy_config, user_agent):
+def get_requests_session(proxy_config):
+    user_agent = '%s/%s' % (Extension.dist_name, __version__)
     proxy = httpclient.format_proxy(proxy_config)
     full_user_agent = httpclient.format_user_agent(user_agent)
 

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -1,0 +1,81 @@
+from __future__ import unicode_literals
+
+import logging
+import time
+
+import requests
+
+from mopidy_spotify import utils
+
+logger = logging.getLogger(__name__)
+
+
+class Error(Exception):
+    pass
+
+
+class OAuthClient(object):
+
+    def __init__(self, refresh_url, client_id=None, client_secret=None,
+                 proxy_config=None, expiry_margin=60):
+
+        if client_id and client_secret:
+            self._auth = (client_id, client_secret)
+        else:
+            self._auth = None
+
+        self._refresh_url = refresh_url
+
+        self._margin = expiry_margin
+        self._expires = 0
+
+        self._headers = {'Content-Type': 'application/json'}
+        self._session = utils.get_requests_session(proxy_config or {})
+
+    def _request(self, method, url, **kwargs):
+        try:
+            resp = self._session.request(method=method, url=url, **kwargs)
+            resp.raise_for_status()
+            return resp
+        except requests.RequestException as e:
+            raise Error('Fetching %s failed: %s' % (url, e))
+
+    def _decode(self, resp):
+        try:
+            return resp.json()
+        except ValueError as e:
+            raise Error('JSON decoding %s failed: %s' % (resp.request.url, e))
+
+    def _should_refresh_token(self):
+        return not self._auth or time.time() > self._expires - self._margin
+
+    def _refresh_token(self):
+        logger.debug('Fetching OAuth token from %s', self._refresh_url)
+
+        resp = self._request('POST', self._refresh_url, auth=self._auth,
+                             data={'grant_type': 'client_credentials'})
+        data = self._decode(resp)
+
+        if data.get('error'):
+            raise Error('OAuth response returned error: %s %s' % (
+                        data['error'], data.get('error_description', '')))
+        elif not data.get('access_token'):
+            raise Error('OAuth response missing access_token.' %
+                        self._refresh_url)
+        elif data.get('token_type') != 'Bearer':
+            raise Error('OAuth response from %s has wrong token_type: %s' % (
+                        self._refresh_url, data.get('token_type')))
+
+        self._headers['Authorization'] = 'Bearer %s' % data['access_token']
+        self._expires = time.time() + data.get('expires_in', float('Inf'))
+
+        if data.get('expires_in'):
+            logger.debug('Token expires in %s seconds.', data['expires_in'])
+        if data.get('scope'):
+            logger.debug('Token scopes: %s', data['scope'])
+
+    def get(self, url, **kwargs):
+        if self._should_refresh_token():
+            self._refresh_token()
+        kwargs.setdefault('headers', {}).update(self._headers)
+        return self._request('GET', url, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 import spotify
 
-from mopidy_spotify import backend, library
+from mopidy_spotify import backend, library, web
 
 
 @pytest.fixture
@@ -34,6 +34,8 @@ def config(tmpdir):
             'search_artist_count': 10,
             'search_track_count': 50,
             'toplist_countries': ['GB', 'US'],
+            'client_id': 'abcd1234',
+            'client_secret': 'YWJjZDEyMzQ='
         }
     }
 
@@ -334,6 +336,16 @@ def web_track_mock(web_artist_mock, web_album_mock):
 
 
 @pytest.fixture
+def web_oauth_mock():
+    return {
+        'access_token': 'NgCXRK...MzYjw',
+        'token_type': 'Bearer',
+        'scope': 'user-read-private user-read-email',
+        'expires_in': 3600,
+    }
+
+
+@pytest.fixture
 def mopidy_artist_mock():
     return models.Artist(
         name='ABBA',
@@ -358,11 +370,18 @@ def session_mock():
 
 
 @pytest.fixture
-def backend_mock(session_mock, config):
+def web_client_mock():
+    web_client_mock = mock.Mock(spec=web.OAuthClient)
+    return web_client_mock
+
+
+@pytest.fixture
+def backend_mock(session_mock, config, web_client_mock):
     backend_mock = mock.Mock(spec=backend.SpotifyBackend)
     backend_mock._config = config
     backend_mock._session = session_mock
     backend_mock._bitrate = 160
+    backend_mock._web_client = web_client_mock
     return backend_mock
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -111,11 +111,27 @@ def test_on_start_configures_proxy(spotify_mock, config):
     }
     spotify_config = spotify_mock.Config.return_value
 
-    get_backend(config).on_start()
+    backend = get_backend(config)
+    backend.on_start()
 
     assert spotify_config.proxy == 'https://my-proxy.example.com:8080'
     assert spotify_config.proxy_username == 'alice'
     assert spotify_config.proxy_password == 's3cret'
+
+    assert (backend._web_client._session.proxies['https'] ==
+            'https://alice:s3cret@my-proxy.example.com:8080')
+
+
+def test_on_start_configures_web_client(spotify_mock, config):
+    config['spotify']['client_id'] = '1234567'
+    config['spotify']['client_secret'] = 'AbCdEfG'
+
+    backend = get_backend(config)
+    backend.on_start()
+
+    assert backend._web_client._auth == ('1234567', 'AbCdEfG')
+    assert (backend._web_client._refresh_url ==
+            'https://auth.mopidy.com/spotify/token')
 
 
 def test_on_start_adds_connection_state_changed_handler_to_session(

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,14 +1,9 @@
 from __future__ import unicode_literals
 
-import json
-
 from mopidy import models
 
 import pytest
 
-import responses
-
-import mopidy_spotify
 from mopidy_spotify import images
 
 
@@ -18,55 +13,47 @@ def img_provider(provider):
     return provider
 
 
-@responses.activate
-def test_get_artist_images(img_provider):
+def test_get_artist_images(web_client_mock, img_provider):
     uris = [
         'spotify:artist:4FCGgZrVQtcbDFEap3OAb2',
         'http://open.spotify.com/artist/0Nsz79ZcE8E4i3XZhCzZ1l',
     ]
 
-    responses.add(
-        responses.GET, 'https://api.spotify.com/v1/artists/',
-        body=json.dumps({
-            'artists': [
-                {
-                    'id': '4FCGgZrVQtcbDFEap3OAb2',
-                    'images': [
-                        {
-                            'height': 640,
-                            'url': 'img://1/a',
-                            'width': 640,
-                        },
-                        {
-                            'height': 300,
-                            'url': 'img://1/b',
-                            'width': 300,
-                        },
-                    ]
-                },
-                {
-                    'id': '0Nsz79ZcE8E4i3XZhCzZ1l',
-                    'images': [
-                        {
-                            'height': 64,
-                            'url': 'img://2/a',
-                            'width': 64
-                        }
-                    ]
-                }
-            ]
-        })
-    )
+    web_client_mock.get.return_value = {
+        'artists': [
+            {
+                'id': '4FCGgZrVQtcbDFEap3OAb2',
+                'images': [
+                    {
+                        'height': 640,
+                        'url': 'img://1/a',
+                        'width': 640,
+                    },
+                    {
+                        'height': 300,
+                        'url': 'img://1/b',
+                        'width': 300,
+                    },
+                ]
+            },
+            {
+                'id': '0Nsz79ZcE8E4i3XZhCzZ1l',
+                'images': [
+                    {
+                        'height': 64,
+                        'url': 'img://2/a',
+                        'width': 64
+                    }
+                ]
+            }
+        ]
+    }
 
     result = img_provider.get_images(uris)
 
-    assert len(responses.calls) == 1
-    assert (
-        responses.calls[0].request.url ==
+    web_client_mock.get.assert_called_once_with(
         'https://api.spotify.com/v1/artists/?ids='
         '4FCGgZrVQtcbDFEap3OAb2,0Nsz79ZcE8E4i3XZhCzZ1l')
-    assert responses.calls[0].request.headers['User-Agent'].startswith(
-        'Mopidy-Spotify/%s' % mopidy_spotify.__version__)
 
     assert len(result) == 2
     assert sorted(result.keys()) == sorted(uris)
@@ -93,35 +80,29 @@ def test_get_artist_images(img_provider):
     assert image2a.width == 64
 
 
-@responses.activate
-def test_get_album_images(img_provider):
+def test_get_album_images(web_client_mock, img_provider):
     uris = [
         'http://play.spotify.com/album/1utFPuvgBHXzLJdqhCDOkg',
     ]
 
-    responses.add(
-        responses.GET, 'https://api.spotify.com/v1/albums/',
-        body=json.dumps({
-            'albums': [
-                {
-                    'id': '1utFPuvgBHXzLJdqhCDOkg',
-                    'images': [
-                        {
-                            'height': 640,
-                            'url': 'img://1/a',
-                            'width': 640,
-                        }
-                    ]
-                }
-            ]
-        })
-    )
+    web_client_mock.get.return_value = {
+        'albums': [
+            {
+                'id': '1utFPuvgBHXzLJdqhCDOkg',
+                'images': [
+                    {
+                        'height': 640,
+                        'url': 'img://1/a',
+                        'width': 640,
+                    }
+                ]
+            }
+        ]
+    }
 
     result = img_provider.get_images(uris)
 
-    assert len(responses.calls) == 1
-    assert (
-        responses.calls[0].request.url ==
+    web_client_mock.get.assert_called_once_with(
         'https://api.spotify.com/v1/albums/?ids=1utFPuvgBHXzLJdqhCDOkg')
 
     assert len(result) == 1
@@ -135,38 +116,32 @@ def test_get_album_images(img_provider):
     assert image.width == 640
 
 
-@responses.activate
-def test_get_track_images(img_provider):
+def test_get_track_images(web_client_mock, img_provider):
     uris = [
         'spotify:track:41shEpOKyyadtG6lDclooa',
     ]
 
-    responses.add(
-        responses.GET, 'https://api.spotify.com/v1/tracks/',
-        body=json.dumps({
-            'tracks': [
-                {
-                    'id': '41shEpOKyyadtG6lDclooa',
-                    'album': {
-                        'uri': 'spotify:album:1utFPuvgBHXzLJdqhCDOkg',
-                        'images': [
-                            {
-                                'height': 640,
-                                'url': 'img://1/a',
-                                'width': 640,
-                            }
-                        ]
-                    }
+    web_client_mock.get.return_value = {
+        'tracks': [
+            {
+                'id': '41shEpOKyyadtG6lDclooa',
+                'album': {
+                    'uri': 'spotify:album:1utFPuvgBHXzLJdqhCDOkg',
+                    'images': [
+                        {
+                            'height': 640,
+                            'url': 'img://1/a',
+                            'width': 640,
+                        }
+                    ]
                 }
-            ]
-        })
-    )
+            }
+        ]
+    }
 
     result = img_provider.get_images(uris)
 
-    assert len(responses.calls) == 1
-    assert (
-        responses.calls[0].request.url ==
+    web_client_mock.get.assert_called_once_with(
         'https://api.spotify.com/v1/tracks/?ids=41shEpOKyyadtG6lDclooa')
 
     assert len(result) == 1
@@ -180,54 +155,49 @@ def test_get_track_images(img_provider):
     assert image.width == 640
 
 
-@responses.activate
-def test_results_are_cached(img_provider):
+def test_results_are_cached(web_client_mock, img_provider):
     uris = [
         'spotify:track:41shEpOKyyadtG6lDclooa',
     ]
 
-    responses.add(
-        responses.GET, 'https://api.spotify.com/v1/tracks/',
-        body=json.dumps({
-            'tracks': [
-                {
-                    'id': '41shEpOKyyadtG6lDclooa',
-                    'album': {
-                        'uri': 'spotify:album:1utFPuvgBHXzLJdqhCDOkg',
-                        'images': [
-                            {
-                                'height': 640,
-                                'url': 'img://1/a',
-                                'width': 640,
-                            }
-                        ]
-                    }
+    web_client_mock.get.return_value = {
+        'tracks': [
+            {
+                'id': '41shEpOKyyadtG6lDclooa',
+                'album': {
+                    'uri': 'spotify:album:1utFPuvgBHXzLJdqhCDOkg',
+                    'images': [
+                        {
+                            'height': 640,
+                            'url': 'img://1/a',
+                            'width': 640,
+                        }
+                    ]
                 }
-            ]
-        })
-    )
+            }
+        ]
+    }
 
     result1 = img_provider.get_images(uris)
     result2 = img_provider.get_images(uris)
 
-    assert len(responses.calls) == 1
+    web_client_mock.get.assert_called_once()
     assert result1 == result2
 
 
-@responses.activate
-def test_max_50_ids_per_request(img_provider):
+def test_max_50_ids_per_request(web_client_mock, img_provider):
     uris = ['spotify:track:%d' % i for i in range(51)]
 
-    responses.add(responses.GET, '', body=json.dumps({}))
+    web_client_mock.get.return_value = {}
 
     img_provider.get_images(uris)
 
-    assert len(responses.calls) == 2
+    assert web_client_mock.get.call_count == 2
 
-    request_url_1 = responses.calls[0].request.url
+    request_url_1 = web_client_mock.get.call_args_list[0][0][0]
     assert request_url_1.endswith(','.join(str(i) for i in range(50)))
 
-    request_url_2 = responses.calls[1].request.url
+    request_url_2 = web_client_mock.get.call_args_list[1][0][0]
     assert request_url_2.endswith('ids=50')
 
 
@@ -244,22 +214,8 @@ def test_no_uris_gives_no_results(img_provider):
     assert result == {}
 
 
-@responses.activate
-def test_service_returns_invalid_json(img_provider, caplog):
-    responses.add(
-        responses.GET, 'https://api.spotify.com/v1/tracks/', body='abc')
-
-    result = img_provider.get_images(['spotify:track:41shEpOKyyadtG6lDclooa'])
-
-    assert result == {}
-    assert "JSON decoding failed for" in caplog.text()
-
-
-@responses.activate
-def test_service_returns_empty_result(img_provider):
-    responses.add(
-        responses.GET, 'https://api.spotify.com/v1/tracks/',
-        body=json.dumps({'tracks': [{}]}))
+def test_service_returns_empty_result(web_client_mock, img_provider):
+    web_client_mock.get.return_value = {'tracks': [{}]}
 
     result = img_provider.get_images(['spotify:track:41shEpOKyyadtG6lDclooa'])
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,206 @@
+from __future__ import unicode_literals
+
+import mock
+
+import pytest
+
+import responses
+
+import mopidy_spotify
+from mopidy_spotify import web
+
+
+@pytest.fixture
+def oauth_client(config):
+    return web.OAuthClient(
+        refresh_url='https://auth.mopidy.com/spotify/token',
+        client_id=config['spotify']['client_id'],
+        client_secret=config['spotify']['client_secret'],
+        proxy_config=None,
+        expiry_margin=60)
+
+
+@pytest.yield_fixture()
+def mock_time():
+    patcher = mock.patch.object(web.time, 'time')
+    mock_time = patcher.start()
+    yield mock_time
+    patcher.stop()
+
+
+def test_initial_refresh_token(oauth_client):
+    assert oauth_client._should_refresh_token()
+
+
+def test_expired_refresh_token(oauth_client, mock_time):
+    oauth_client._expires = 1060
+    mock_time.return_value = 1001
+    assert oauth_client._should_refresh_token()
+
+
+def test_still_valid_refresh_token(oauth_client, mock_time):
+    oauth_client._expires = 1060
+    mock_time.return_value = 1000
+    assert not oauth_client._should_refresh_token()
+
+
+def test_user_agent(oauth_client):
+    assert oauth_client._session.headers['user-agent'].startswith(
+        'Mopidy-Spotify/%s' % mopidy_spotify.__version__)
+
+
+@responses.activate
+def test_get_uses_new_access_token(
+        web_oauth_mock, web_track_mock, mock_time, oauth_client):
+    responses.add(
+        responses.POST, 'https://auth.mopidy.com/spotify/token',
+        json=web_oauth_mock)
+    responses.add(
+        responses.GET, 'https://api.spotify.com/v1/tracks/abc',
+        json=web_track_mock)
+    mock_time.return_value = 1000
+
+    result = oauth_client.get('https://api.spotify.com/v1/tracks/abc')
+
+    assert len(responses.calls) == 2
+    assert (responses.calls[0].request.url ==
+            'https://auth.mopidy.com/spotify/token')
+    assert (responses.calls[1].request.url ==
+            'https://api.spotify.com/v1/tracks/abc')
+    assert (responses.calls[1].request.headers['Authorization'] ==
+            'Bearer NgCXRK...MzYjw')
+
+    assert oauth_client._headers['Authorization'] == 'Bearer NgCXRK...MzYjw'
+    assert oauth_client._expires == 4600
+
+    assert result['uri'] == 'spotify:track:abc'
+
+
+@responses.activate
+def test_get_uses_existing_access_token(
+        web_oauth_mock, web_track_mock, mock_time, oauth_client):
+    responses.add(
+        responses.POST, 'https://auth.mopidy.com/spotify/token',
+        json=web_oauth_mock)
+    responses.add(
+        responses.GET, 'https://api.spotify.com/v1/tracks/abc',
+        json=web_track_mock)
+    mock_time.return_value = -1000
+
+    oauth_client._headers['Authorization'] = 'Bearer 01234...abcde'
+
+    result = oauth_client.get('https://api.spotify.com/v1/tracks/abc')
+
+    assert len(responses.calls) == 1
+    assert (responses.calls[0].request.url ==
+            'https://api.spotify.com/v1/tracks/abc')
+    assert (responses.calls[0].request.headers['Authorization'] ==
+            'Bearer 01234...abcde')
+
+    assert oauth_client._headers['Authorization'] == 'Bearer 01234...abcde'
+    assert result['uri'] == 'spotify:track:abc'
+
+
+@responses.activate
+def test_bad_client_credentials(oauth_client):
+    bad_response = {
+        'error': 'invalid_client',
+        'error_description': 'Client not known.'}
+    responses.add(
+        responses.POST, 'https://auth.mopidy.com/spotify/token',
+        json=bad_response, status=401)
+
+    result = oauth_client.get('https://api.spotify.com/v1/tracks/abc')
+
+    assert result == {}
+
+
+@responses.activate
+def test_auth_returns_invalid_json(oauth_client, caplog):
+    responses.add(
+        responses.POST, 'https://auth.mopidy.com/spotify/token', body='scope')
+
+    result = oauth_client.get('https://api.spotify.com/v1/tracks/abc')
+
+    assert result == {}
+    assert ('JSON decoding https://auth.mopidy.com/spotify/token failed' in
+            caplog.text())
+
+
+@responses.activate
+def test_spotify_returns_invalid_json(mock_time, oauth_client, caplog):
+    responses.add(
+        responses.GET, 'https://api.spotify.com/v1/tracks/abc',
+        body='abc')
+    mock_time.return_value = -1000
+
+    result = oauth_client.get('https://api.spotify.com/v1/tracks/abc')
+
+    assert result == {}
+    assert ('JSON decoding https://api.spotify.com/v1/tracks/abc failed' in
+            caplog.text())
+
+
+@responses.activate
+def test_auth_offline(oauth_client, caplog):
+    responses.add(
+        responses.POST, 'https://auth.mopidy.com/spotify/token',
+        json={"error": "not found"}, status=404)
+
+    result = oauth_client.get('https://api.spotify.com/v1/tracks/abc')
+
+    assert result == {}
+    assert ('Fetching https://auth.mopidy.com/spotify/token failed' in
+            caplog.text())
+
+
+@responses.activate
+def test_spotify_offline(web_oauth_mock, oauth_client, caplog):
+    responses.add(
+        responses.POST, 'https://auth.mopidy.com/spotify/token',
+        json=web_oauth_mock)
+    responses.add(
+        responses.GET, 'https://api.spotify.com/v1/tracks/abc',
+        json={"error": "not found"}, status=404)
+
+    result = oauth_client.get('https://api.spotify.com/v1/tracks/abc')
+
+    assert result == {}
+    assert ('Fetching https://api.spotify.com/v1/tracks/abc failed' in
+            caplog.text())
+
+
+@responses.activate
+def test_auth_missing_access_token(web_oauth_mock, oauth_client, caplog):
+    no_access_token = web_oauth_mock
+    del(no_access_token['access_token'])
+    responses.add(
+        responses.POST, 'https://auth.mopidy.com/spotify/token',
+        json=no_access_token)
+
+    oauth_client._headers['Authorization'] = 'Bearer 01234...abcde'
+
+    result = oauth_client.get('https://api.spotify.com/v1/tracks/abc')
+
+    assert len(responses.calls) == 1
+    assert oauth_client._headers['Authorization'] == 'Bearer 01234...abcde'
+    assert result == {}
+    assert 'OAuth token refresh failed: missing access_token' in caplog.text()
+
+
+@responses.activate
+def test_auth_wrong_token_type(web_oauth_mock, oauth_client, caplog):
+    wrong_token_type = web_oauth_mock
+    wrong_token_type['token_type'] = 'something'
+    responses.add(
+        responses.POST, 'https://auth.mopidy.com/spotify/token',
+        json=wrong_token_type)
+
+    oauth_client._headers['Authorization'] = 'Bearer 01234...abcde'
+
+    result = oauth_client.get('https://api.spotify.com/v1/tracks/abc')
+
+    assert len(responses.calls) == 1
+    assert oauth_client._headers['Authorization'] == 'Bearer 01234...abcde'
+    assert result == {}
+    assert 'OAuth token refresh failed: wrong token_type' in caplog.text()


### PR DESCRIPTION
Fixes and tests for @adamcik's original branch.

Still need to consider (from #130):

- [x] check for id/secret from spotify_web, though that would mean making the new ones optional?