### PR TITLE
Pause spotify playback when Mopidy paused

### DIFF
--- a/mopidy_spotify/playback.py
+++ b/mopidy_spotify/playback.py
@@ -98,6 +98,11 @@ class SpotifyPlaybackProvider(backend.PlaybackProvider):
         self.backend._session.player.pause()
         return super(SpotifyPlaybackProvider, self).stop()
 
+    def pause(self):
+        logger.debug('Audio requested pause; pausing Spotify player')
+        self.backend._session.player.pause()
+        return super(SpotifyPlaybackProvider, self).pause()
+
     def on_seek_data(self, time_position):
         logger.debug('Audio requested seek to %d', time_position)
 

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -132,6 +132,12 @@ def test_stop_pauses_spotify_playback(session_mock, provider):
     session_mock.player.pause.assert_called_once_with()
 
 
+def test_pause_pauses_spotify_playback(session_mock, provider):
+    provider.pause()
+
+    session_mock.player.pause.assert_called_once_with()
+
+
 def test_on_seek_data_updates_timestamp_and_seeks_in_spotify(
         session_mock, provider):
     provider.on_seek_data(1780)


### PR DESCRIPTION
Previously, when paused, we stopped consuming audio buffers rather than telling libspotify to pause playback. This lead to undesirable behaviour on other clients if the "paused" mopidy-spotify instance was offline at the time playback was started on another Spotify client, causing it to miss the playback token lost signal from the other client (see #146).