### PR TITLE
Web client caching

### DIFF
--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -9,8 +9,6 @@ import urllib
 import urlparse
 from datetime import datetime
 
-from mopidy.internal import log
-
 import requests
 
 from mopidy_spotify import utils
@@ -19,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def _trace(*args, **kwargs):
-    logger.log(log.TRACE_LOG_LEVEL, *args, **kwargs)
+    logger.log(utils.TRACE, *args, **kwargs)
 
 
 class OAuthTokenRefreshError(Exception):

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -274,7 +274,7 @@ class OAuthClient(object):
             # currently ignoring this.
             # Format is string of ASCII characters placed between double quotes
             # but can seemingly also include hyphen characters.
-            etag = re.match(r'^(W/)?("[\w-]+")$', value)
+            etag = re.match(r'^(W/)?("[!#-~]+")$', value)
             if etag and len(etag.groups()) == 2:
                 return etag.groups()[1]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -346,6 +346,13 @@ def web_track_mock(web_artist_mock, web_album_mock):
 
 
 @pytest.fixture
+def web_response_mock(web_track_mock):
+    return web.WebResponse(
+        'https://api.spotify.com/v1/tracks/abc', web_track_mock, expires=1000,
+        status_code=200)
+
+
+@pytest.fixture
 def web_oauth_mock():
     return {
         'access_token': 'NgCXRK...MzYjw',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -353,6 +353,13 @@ def web_response_mock(web_track_mock):
 
 
 @pytest.fixture
+def web_response_mock_etag(web_track_mock):
+    return web.WebResponse(
+        'https://api.spotify.com/v1/tracks/abc', web_track_mock, expires=1000,
+        etag='"1234"', status_code=200)
+
+
+@pytest.fixture
 def web_oauth_mock():
     return {
         'access_token': 'NgCXRK...MzYjw',

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -216,11 +216,11 @@ def test_auth_wrong_token_type(web_oauth_mock, oauth_client, caplog):
     ('max-age=junk', 100),
     ('', 100),
 ])
-def test_parse_cache_control(mock_time, oauth_client, header, expected):
+def test_parse_cache_control(mock_time, header, expected):
     mock_time.return_value = 100
     mock_response = mock.Mock(headers={'Cache-Control': header})
 
-    expires = oauth_client._parse_cache_control(mock_response)
+    expires = web.WebResponse._parse_cache_control(mock_response)
     assert expires == expected
 
 
@@ -234,11 +234,11 @@ def test_parse_cache_control(mock_time, oauth_client, header, expected):
     ('W/"33a6ff"', '"33a6ff"'),
     ('"#aa44-cc1-23==@!"', '"#aa44-cc1-23==@!"'),
 ])
-def test_parse_etag(oauth_client, header, expected):
+def test_parse_etag(header, expected):
     mock_time.return_value = 100
     mock_response = mock.Mock(headers={'ETag': header})
 
-    expires = oauth_client._parse_etag(mock_response)
+    expires = web.WebResponse._parse_etag(mock_response)
     assert expires == expected
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -226,10 +226,13 @@ def test_parse_cache_control(mock_time, oauth_client, header, expected):
 
 @pytest.mark.parametrize('header,expected', [
     ('', None),
+    ('" "', None),
+    ('33a6ff', None),
     ('"33a6ff"', '"33a6ff"'),
+    ('"33"a6ff"', None),
+    ('"33\na6ff"', None),
     ('W/"33a6ff"', '"33a6ff"'),
-    ('"aa44-cc1-23"', '"aa44-cc1-23"'),
-    ('"aa&@@5"', None),
+    ('"#aa44-cc1-23==@!"', '"#aa44-cc1-23==@!"'),
 ])
 def test_parse_etag(oauth_client, header, expected):
     mock_time.return_value = 100


### PR DESCRIPTION
This adds caching to the web client and is required for decent performance when using Spotify's Web API for playlist data (https://github.com/mopidy/mopidy-spotify/issues/182, https://github.com/mopidy/mopidy-spotify/pull/188).

This supports expiry times calculated from the [Cache-Control header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) as well as [ETags](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) to detect unmodified response data once it's expired.

This part of the fix is self-contained and it seemed reasonable to split it out. I think I've also improved the code in doing so. Hopefully this will also make reviewing easier. 