### PR TITLE
Updated tests for breaking changes in latest pytest.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 pytest
 pytest-cov
-pytest-capturelog
 mock
 responses

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,13 @@ import pytest
 
 import spotify
 
-from mopidy_spotify import backend, library, web
+from mopidy_spotify import backend, library, utils, web
+
+
+@pytest.yield_fixture()
+def caplog(caplog):
+    caplog.set_level(utils.TRACE)
+    return caplog
 
 
 @pytest.fixture

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -185,7 +185,7 @@ def test_on_stop_logs_out_and_waits_for_logout_to_complete(
 
     backend.on_stop()
 
-    assert 'Logging out of Spotify' in caplog.text()
+    assert 'Logging out of Spotify' in caplog.text
     backend._session.logout.assert_called_once_with()
     backend._logged_out.wait.assert_called_once_with()
     backend._event_loop.stop.assert_called_once_with()
@@ -201,7 +201,7 @@ def test_on_connection_state_changed_when_logged_out(spotify_mock, caplog):
     backend.on_connection_state_changed(
         session_mock, logged_in_event, logged_out_event, actor_mock)
 
-    assert 'Logged out of Spotify' in caplog.text()
+    assert 'Logged out of Spotify' in caplog.text
     assert not logged_in_event.is_set()
     assert logged_out_event.is_set()
 
@@ -216,7 +216,7 @@ def test_on_connection_state_changed_when_logged_in(spotify_mock, caplog):
     backend.on_connection_state_changed(
         session_mock, logged_in_event, logged_out_event, actor_mock)
 
-    assert 'Logged in to Spotify in online mode' in caplog.text()
+    assert 'Logged in to Spotify in online mode' in caplog.text
     assert logged_in_event.is_set()
     assert not logged_out_event.is_set()
     actor_mock.on_logged_in.assert_called_once_with()
@@ -232,7 +232,7 @@ def test_on_connection_state_changed_when_disconnected(spotify_mock, caplog):
     backend.on_connection_state_changed(
         session_mock, logged_in_event, logged_out_event, actor_mock)
 
-    assert 'Disconnected from Spotify' in caplog.text()
+    assert 'Disconnected from Spotify' in caplog.text
 
 
 def test_on_connection_state_changed_when_offline(spotify_mock, caplog):
@@ -245,7 +245,7 @@ def test_on_connection_state_changed_when_offline(spotify_mock, caplog):
     backend.on_connection_state_changed(
         session_mock, logged_in_event, logged_out_event, actor_mock)
 
-    assert 'Logged in to Spotify in offline mode' in caplog.text()
+    assert 'Logged in to Spotify in offline mode' in caplog.text
     assert logged_in_event.is_set()
     assert not logged_out_event.is_set()
 
@@ -260,7 +260,7 @@ def test_on_logged_in_event_activates_private_session(
 
     backend.on_logged_in()
 
-    assert 'Spotify private session activated' in caplog.text()
+    assert 'Spotify private session activated' in caplog.text
     private_session_mock.assert_called_once_with(True)
 
 
@@ -322,7 +322,7 @@ def test_on_play_token_lost_messages_the_actor(spotify_mock, caplog):
 
     backend.on_play_token_lost(session_mock, actor_mock)
 
-    assert 'Spotify play token lost' in caplog.text()
+    assert 'Spotify play token lost' in caplog.text
     actor_mock.on_play_token_lost.assert_called_once_with()
 
 
@@ -336,7 +336,7 @@ def test_on_play_token_lost_event_when_playing(spotify_mock, config, caplog):
 
     assert (
         'Spotify has been paused because your account is '
-        'being used somewhere else.' in caplog.text())
+        'being used somewhere else.' in caplog.text)
     backend.playback.pause.assert_called_once_with()
 
 
@@ -349,5 +349,5 @@ def test_on_play_token_lost_event_when_not_playing(
 
     backend.on_play_token_lost()
 
-    assert 'Spotify has been paused' not in caplog.text()
+    assert 'Spotify has been paused' not in caplog.text
     assert backend.playback.pause.call_count == 0

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -11,7 +11,7 @@ def test_lookup_of_invalid_uri(session_mock, provider, caplog):
     results = provider.lookup('invalid')
 
     assert len(results) == 0
-    assert 'Failed to lookup "invalid": an error message' in caplog.text()
+    assert 'Failed to lookup "invalid": an error message' in caplog.text
 
 
 def test_lookup_of_unhandled_uri(session_mock, provider, caplog):
@@ -24,7 +24,7 @@ def test_lookup_of_unhandled_uri(session_mock, provider, caplog):
     assert len(results) == 0
     assert (
         'Failed to lookup "something": Cannot handle <LinkType.INVALID: 0>'
-        in caplog.text())
+        in caplog.text)
 
 
 def test_lookup_when_offline(session_mock, sp_track_mock, provider, caplog):
@@ -37,7 +37,7 @@ def test_lookup_when_offline(session_mock, sp_track_mock, provider, caplog):
     assert len(results) == 0
     assert (
         'Failed to lookup "spotify:track:abc": Must be online to load objects'
-        in caplog.text())
+        in caplog.text)
 
 
 def test_lookup_of_track_uri(session_mock, sp_track_mock, provider):

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -180,7 +180,7 @@ def test_create_with_invalid_name(session_mock, provider, caplog):
     assert playlist is None
     assert (
         'Failed creating new Spotify playlist "Foo": Too long name'
-        in caplog.text())
+        in caplog.text)
 
 
 def test_create_fails_in_libspotify(session_mock, provider, caplog):
@@ -192,14 +192,14 @@ def test_create_fails_in_libspotify(session_mock, provider, caplog):
     playlist = provider.create('Foo')
 
     assert playlist is None
-    assert 'Failed creating new Spotify playlist "Foo"' in caplog.text()
+    assert 'Failed creating new Spotify playlist "Foo"' in caplog.text
 
 
 def test_on_container_loaded_triggers_playlists_loaded_event(
         sp_playlist_container_mock, caplog, backend_listener_mock):
     playlists.on_container_loaded(sp_playlist_container_mock)
 
-    assert 'Spotify playlist container loaded' in caplog.text()
+    assert 'Spotify playlist container loaded' in caplog.text
     backend_listener_mock.send.assert_called_once_with('playlists_loaded')
 
 
@@ -209,7 +209,7 @@ def test_on_playlist_added_does_nothing_yet(
     playlists.on_playlist_added(
         sp_playlist_container_mock, sp_playlist_mock, 0)
 
-    assert 'Spotify playlist "Foo" added to index 0' in caplog.text()
+    assert 'Spotify playlist "Foo" added to index 0' in caplog.text
     assert backend_listener_mock.send.call_count == 0
 
 
@@ -219,7 +219,7 @@ def test_on_playlist_removed_does_nothing_yet(
     playlists.on_playlist_removed(
         sp_playlist_container_mock, sp_playlist_mock, 0)
 
-    assert 'Spotify playlist "Foo" removed from index 0' in caplog.text()
+    assert 'Spotify playlist "Foo" removed from index 0' in caplog.text
     assert backend_listener_mock.send.call_count == 0
 
 
@@ -229,5 +229,5 @@ def test_on_playlist_moved_does_nothing_yet(
     playlists.on_playlist_moved(
         sp_playlist_container_mock, sp_playlist_mock, 0, 1)
 
-    assert 'Spotify playlist "Foo" moved from index 0 to 1' in caplog.text()
+    assert 'Spotify playlist "Foo" moved from index 0 to 1' in caplog.text
     assert backend_listener_mock.send.call_count == 0

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -13,7 +13,7 @@ def test_search_with_no_query_returns_nothing(provider, caplog):
     assert isinstance(result, models.SearchResult)
     assert result.uri == 'spotify:search'
     assert len(result.tracks) == 0
-    assert 'Ignored search without query' in caplog.text()
+    assert 'Ignored search without query' in caplog.text
 
 
 def test_search_with_empty_query_returns_nothing(provider, caplog):
@@ -22,7 +22,7 @@ def test_search_with_empty_query_returns_nothing(provider, caplog):
     assert isinstance(result, models.SearchResult)
     assert result.uri == 'spotify:search'
     assert len(result.tracks) == 0
-    assert 'Ignored search with empty query' in caplog.text()
+    assert 'Ignored search with empty query' in caplog.text
 
 
 def test_search_by_single_uri(session_mock, sp_track_mock, provider):
@@ -60,7 +60,7 @@ def test_search_when_offline_returns_nothing(session_mock, provider, caplog):
 
     result = provider.search({'any': ['ABBA']})
 
-    assert 'Spotify search aborted: Spotify is offline' in caplog.text()
+    assert 'Spotify search aborted: Spotify is offline' in caplog.text
 
     assert isinstance(result, models.SearchResult)
     assert result.uri == 'spotify:search:%22ABBA%22'
@@ -80,7 +80,7 @@ def test_search_returns_albums_and_artists_and_tracks(
             'market': 'GB',
             'type': 'album,artist,track'})
 
-    assert 'Searching Spotify for: "ABBA"' in caplog.text()
+    assert 'Searching Spotify for: "ABBA"' in caplog.text
 
     assert isinstance(result, models.SearchResult)
     assert result.uri == 'spotify:search:%22ABBA%22'

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -164,7 +164,7 @@ class TestToTrack(object):
         assert track is None
         assert (
             'Error loading spotify:track:abc: <ErrorType.OTHER_PERMANENT: 10>'
-            in caplog.text())
+            in caplog.text)
 
     def test_returns_none_if_not_available(self, sp_track_mock):
         sp_track_mock.availability = spotify.TrackAvailability.UNAVAILABLE
@@ -223,7 +223,7 @@ class TestToTrackRef(object):
         assert ref is None
         assert (
             'Error loading spotify:track:abc: <ErrorType.OTHER_PERMANENT: 10>'
-            in caplog.text())
+            in caplog.text)
 
     def test_returns_none_if_not_available(self, sp_track_mock):
         sp_track_mock.availability = spotify.TrackAvailability.UNAVAILABLE
@@ -411,7 +411,7 @@ class TestSpotifySearchQuery(object):
         assert query == ''
         assert (
             'Excluded year from search query: Cannot parse date "abc"'
-            in caplog.text())
+            in caplog.text)
 
     def test_anything_can_be_combined(self):
         query = translator.sp_search_query({

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,4 +9,4 @@ def test_time_logger(caplog):
     with utils.time_logger('task'):
         pass
 
-    assert re.match('.*task took \d+ms.*', caplog.text())
+    assert re.match('.*task took \d+ms.*', caplog.text)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -125,7 +125,7 @@ def test_auth_returns_invalid_json(oauth_client, caplog):
 
     assert result == {}
     assert ('JSON decoding https://auth.mopidy.com/spotify/token failed' in
-            caplog.text())
+            caplog.text)
 
 
 @responses.activate
@@ -139,7 +139,7 @@ def test_spotify_returns_invalid_json(mock_time, oauth_client, caplog):
 
     assert result == {}
     assert ('JSON decoding https://api.spotify.com/v1/tracks/abc failed' in
-            caplog.text())
+            caplog.text)
 
 
 @responses.activate
@@ -152,7 +152,7 @@ def test_auth_offline(oauth_client, caplog):
 
     assert result == {}
     assert ('Fetching https://auth.mopidy.com/spotify/token failed' in
-            caplog.text())
+            caplog.text)
 
 
 @responses.activate
@@ -168,7 +168,7 @@ def test_spotify_offline(web_oauth_mock, oauth_client, caplog):
 
     assert result == {}
     assert ('Fetching https://api.spotify.com/v1/tracks/abc failed' in
-            caplog.text())
+            caplog.text)
 
 
 @responses.activate
@@ -186,7 +186,7 @@ def test_auth_missing_access_token(web_oauth_mock, oauth_client, caplog):
     assert len(responses.calls) == 1
     assert oauth_client._headers['Authorization'] == 'Bearer 01234...abcde'
     assert result == {}
-    assert 'OAuth token refresh failed: missing access_token' in caplog.text()
+    assert 'OAuth token refresh failed: missing access_token' in caplog.text
 
 
 @responses.activate
@@ -204,4 +204,4 @@ def test_auth_wrong_token_type(web_oauth_mock, oauth_client, caplog):
     assert len(responses.calls) == 1
     assert oauth_client._headers['Authorization'] == 'Bearer 01234...abcde'
     assert result == {}
-    assert 'OAuth token refresh failed: wrong token_type' in caplog.text()
+    assert 'OAuth token refresh failed: wrong token_type' in caplog.text


### PR DESCRIPTION
* pytest-capturelog plugin was merged into pytest core.
* caplog.text is no longer callable.
* pytest captures log messages of level WARNING or above, we need lower.