### PR TITLE
Workarounds for where we call fixures directly.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,7 +150,6 @@ def sp_album_browser_mock(sp_album_mock, sp_track_mock):
     return sp_album_browser
 
 
-@pytest.fixture
 def sp_track_mock(sp_artist_mock, sp_album_mock):
     sp_track = mock.Mock(spec=spotify.Track)
     sp_track.is_loaded = True
@@ -170,6 +169,11 @@ def sp_track_mock(sp_artist_mock, sp_album_mock):
     sp_track.link = sp_link
 
     return sp_track
+
+
+@pytest.fixture(name="sp_track_mock")
+def sp_track_mock_fixture(sp_artist_mock, sp_album_mock):
+    return sp_track_mock(sp_artist_mock, sp_album_mock)
 
 
 @pytest.fixture

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -6,8 +6,6 @@ from mopidy import models
 
 import spotify
 
-from . import conftest
-
 
 def test_has_a_root_directory(provider):
     assert provider.root_directory == models.Ref.directory(
@@ -191,9 +189,8 @@ def test_browse_top_track_countries_list_limited_by_config(
 
 
 def test_browse_top_tracks_countries_unlimited_by_config(
-        backend_mock):
+        provider, backend_mock):
     backend_mock._config['spotify']['toplist_countries'] = []
-    provider = conftest.provider(backend_mock)
 
     results = provider.browse('spotify:top:tracks:countries')
 

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -52,9 +52,9 @@ def test_is_a_playback_provider(provider):
 
 
 def test_connect_events_adds_music_delivery_handler_to_session(
-        session_mock, audio_mock, backend_mock):
+        session_mock, provider, audio_mock):
 
-    playback_provider = provider(audio_mock, backend_mock)
+    playback_provider = provider
     playback_provider._connect_events()
 
     assert (mock.call(
@@ -68,9 +68,9 @@ def test_connect_events_adds_music_delivery_handler_to_session(
 
 
 def test_connect_events_adds_end_of_track_handler_to_session(
-        session_mock, audio_mock, backend_mock):
+        session_mock, provider, audio_mock):
 
-    playback_provider = provider(audio_mock, backend_mock)
+    playback_provider = provider
     playback_provider._connect_events()
 
     assert (mock.call(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,4 +9,4 @@ def test_time_logger(caplog):
     with utils.time_logger('task'):
         pass
 
-    assert re.match('.*task took \d+ms.*', caplog.text)
+    assert re.match(r'.*task took \d+ms.*', caplog.text)


### PR DESCRIPTION
This became an error in pytest v4.1.0. See https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly

Also flake8 fix for now invalid escape sequence.