### PR TITLE
Fix backend tests compatibility with pykka 2.0.

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -140,13 +140,12 @@ def test_on_start_adds_connection_state_changed_handler_to_session(
 
     get_backend(config).on_start()
 
-    assert (mock.call(
+    session.on.assert_any_call(
         spotify_mock.SessionEvent.CONNECTION_STATE_UPDATED,
         backend.on_connection_state_changed,
         backend.SpotifyBackend._logged_in,
         backend.SpotifyBackend._logged_out,
         mock.ANY)
-        in session.on.call_args_list)
 
 
 def test_on_start_adds_play_token_lost_handler_to_session(
@@ -156,10 +155,10 @@ def test_on_start_adds_play_token_lost_handler_to_session(
     obj = get_backend(config)
     obj.on_start()
 
-    assert (mock.call(
+    session.on.assert_any_call(
         spotify_mock.SessionEvent.PLAY_TOKEN_LOST,
-        backend.on_play_token_lost, mock.ANY)
-        in session.on.call_args_list)
+        backend.on_play_token_lost,
+        mock.ANY)
 
 
 def test_on_start_starts_the_pyspotify_event_loop(spotify_mock, config):


### PR DESCRIPTION
When asserting `mock.call in list(some_call)`, the `some_call` ends up on the lhs.
In our failing test cases, the `some_call` on the lhs includes an `ActorProxy` and the `mock.call` on the rhs includes the `mock.ANY`, so we get `ActorProxy.__eq__(mock.ANY)`, [which returns False](https://github.com/jodal/pykka/blob/develop/pykka/_proxy.py#L186-L188).
In Pykka 1.x there was no `ActorProxy.__eq__()` defined so we ended up doing `mock.ANY.__eq__(ActorProxy)`, [which returned True](https://github.com/python/cpython/blob/2.7/Lib/test/_mock_backport.py#L1880). This PR avoids this situation.