### PR TITLE
Use latest travis/tox receipes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,23 @@
-sudo: required
-dist: trusty
-
 language: python
 
 python:
-  - "2.7_with_system_site_packages"
+  - "2.7"
+
+virtualenv:
+  system_site_packages: true
+
+addons:
+  apt:
+    sources:
+      - mopidy-stable
+    packages:
+      - mopidy
+      - python-spotify
 
 env:
   - TOX_ENV=py27
   - TOX_ENV=flake8
-
-before_install:
-  - "wget -q -O - https://apt.mopidy.com/mopidy.gpg | sudo apt-key add -"
-  - "sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/jessie.list"
-  - "sudo apt-get update -qq"
-  - "sudo apt-get install -y gir1.2-gst-plugins-base-1.0 gstreamer1.0-plugins-base gir1.2-gstreamer-1.0 python-gst-1.0 libffi-dev libspotify-dev python-all-dev"
+  - TOX_ENV=check-manifest
 
 install:
   - "pip install tox"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, flake8
+envlist = py27, flake8, check-manifest
 
 [testenv]
 sitepackages = true
@@ -13,8 +13,12 @@ commands =
         {posargs}
 
 [testenv:flake8]
-skip_install = true
 deps =
     flake8
     flake8-import-order
+skip_install = true
 commands = flake8 mopidy_spotify/ setup.py tests/
+
+[testenv:check-manifest]
+deps = check-manifest
+commands = check-manifest


### PR DESCRIPTION
Use the default Travis build environment, which is now Xenial rather than Trusty (Python 2.7.12).