### PR TITLE
Web API playlists v2

### DIFF
--- a/mopidy_spotify/backend.py
+++ b/mopidy_spotify/backend.py
@@ -60,12 +60,11 @@ class SpotifyBackend(pykka.ThreadingActor, backend.Backend):
             self._config['spotify']['username'],
             self._config['spotify']['password'])
 
-        self._web_client = web.OAuthClient(
-            base_url='https://api.spotify.com/v1',
-            refresh_url='https://auth.mopidy.com/spotify/token',
-            client_id=self._config['spotify']['client_id'],
-            client_secret=self._config['spotify']['client_secret'],
-            proxy_config=self._config['proxy'])
+        self._web_client = web.SpotifyOAuthClient(
+            self._config['spotify']['client_id'],
+            self._config['spotify']['client_secret'], self._config['proxy'])
+
+        self._web_client.login()
 
     def on_stop(self):
         logger.debug('Logging out of Spotify')

--- a/mopidy_spotify/backend.py
+++ b/mopidy_spotify/backend.py
@@ -65,6 +65,9 @@ class SpotifyBackend(pykka.ThreadingActor, backend.Backend):
             self._config['spotify']['client_secret'], self._config['proxy'])
         self._web_client.login()
 
+        if self.playlists is not None:
+            self.playlists.refresh()
+
     def on_stop(self):
         logger.debug('Logging out of Spotify')
         self._session.logout()

--- a/mopidy_spotify/backend.py
+++ b/mopidy_spotify/backend.py
@@ -63,7 +63,6 @@ class SpotifyBackend(pykka.ThreadingActor, backend.Backend):
         self._web_client = web.SpotifyOAuthClient(
             self._config['spotify']['client_id'],
             self._config['spotify']['client_secret'], self._config['proxy'])
-
         self._web_client.login()
 
     def on_stop(self):
@@ -121,19 +120,6 @@ class SpotifyBackend(pykka.ThreadingActor, backend.Backend):
         if self._config['spotify']['private_session']:
             logger.info('Spotify private session activated')
             self._session.social.private_session = True
-
-        self._session.playlist_container.on(
-            spotify.PlaylistContainerEvent.CONTAINER_LOADED,
-            playlists.on_container_loaded)
-        self._session.playlist_container.on(
-            spotify.PlaylistContainerEvent.PLAYLIST_ADDED,
-            playlists.on_playlist_added)
-        self._session.playlist_container.on(
-            spotify.PlaylistContainerEvent.PLAYLIST_REMOVED,
-            playlists.on_playlist_removed)
-        self._session.playlist_container.on(
-            spotify.PlaylistContainerEvent.PLAYLIST_MOVED,
-            playlists.on_playlist_moved)
 
     def on_play_token_lost(self):
         if self._session.player.state == spotify.PlayerState.PLAYING:

--- a/mopidy_spotify/library.py
+++ b/mopidy_spotify/library.py
@@ -29,7 +29,9 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
         return images.get_images(self._backend._web_client, uris)
 
     def lookup(self, uri):
-        return lookup.lookup(self._config, self._backend._session, uri)
+        return lookup.lookup(
+            self._config, self._backend._session, self._backend._web_client,
+            uri)
 
     def search(self, query=None, uris=None, exact=False):
         return search.search(

--- a/mopidy_spotify/lookup.py
+++ b/mopidy_spotify/lookup.py
@@ -25,7 +25,7 @@ def lookup(config, session, web_client, uri):
 
     try:
         if web_link.type == 'playlist':
-            return _lookup_playlist(config, web_client, uri)
+            return _lookup_playlist(config, session, web_client, uri)
         elif sp_link.type is spotify.LinkType.TRACK:
             return list(_lookup_track(config, sp_link))
         elif sp_link.type is spotify.LinkType.ALBUM:
@@ -90,8 +90,9 @@ def _lookup_artist(config, sp_link):
                 yield track
 
 
-def _lookup_playlist(config, web_client, uri):
-    playlist = playlists.playlist_lookup(web_client, uri, config['bitrate'])
+def _lookup_playlist(config, session, web_client, uri):
+    playlist = playlists.playlist_lookup(
+        session, web_client, uri, config['bitrate'])
     if playlist is None:
         raise spotify.Error('Playlist Web API lookup failed')
     return playlist.tracks

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -4,10 +4,10 @@ import logging
 
 from mopidy import backend
 
-import spotify
-
 from mopidy_spotify import translator, utils
 
+
+_cache = {}
 
 logger = logging.getLogger(__name__)
 
@@ -23,25 +23,16 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
             return list(self._get_flattened_playlist_refs())
 
     def _get_flattened_playlist_refs(self):
-        if self._backend._session is None:
+        if self._backend._web_client is None:
             return
 
-        if self._backend._session.playlist_container is None:
+        if self._backend._web_client.user_id is None:
             return
 
-        username = self._backend._session.user_name
-        folders = []
-
-        for sp_playlist in self._backend._session.playlist_container:
-            if isinstance(sp_playlist, spotify.PlaylistFolder):
-                if sp_playlist.type is spotify.PlaylistType.START_FOLDER:
-                    folders.append(sp_playlist.name)
-                elif sp_playlist.type is spotify.PlaylistType.END_FOLDER:
-                    folders.pop()
-                continue
-
+        web_client = self._backend._web_client
+        for web_playlist in web_client.get_user_playlists(_cache):
             playlist_ref = translator.to_playlist_ref(
-                sp_playlist, folders=folders, username=username)
+                web_playlist, web_client.user_id)
             if playlist_ref is not None:
                 yield playlist_ref
 
@@ -54,38 +45,15 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
             return self._get_playlist(uri)
 
     def _get_playlist(self, uri, as_items=False):
-        try:
-            sp_playlist = self._backend._session.get_playlist(uri)
-        except spotify.Error as exc:
-            logger.debug('Failed to lookup Spotify URI %s: %s', uri, exc)
-            return
-
-        if not sp_playlist.is_loaded:
-            logger.debug(
-                'Waiting for Spotify playlist to load: %s', sp_playlist)
-            sp_playlist.load(self._timeout)
-
-        username = self._backend._session.user_name
-        return translator.to_playlist(
-            sp_playlist, username=username, bitrate=self._backend._bitrate,
-            as_items=as_items)
+        return playlist_lookup(
+                self._backend._web_client, uri,
+                self._backend._bitrate, as_items)
 
     def refresh(self):
-        pass  # Not needed as long as we don't cache anything.
+        pass  # TODO: Clear/invalidate all caches on refresh.
 
     def create(self, name):
-        try:
-            sp_playlist = (
-                self._backend._session.playlist_container
-                .add_new_playlist(name))
-        except ValueError as exc:
-            logger.warning(
-                'Failed creating new Spotify playlist "%s": %s', name, exc)
-        except spotify.Error:
-            logger.warning('Failed creating new Spotify playlist "%s"', name)
-        else:
-            username = self._backend._session.user_name
-            return translator.to_playlist(sp_playlist, username=username)
+        pass  # TODO
 
     def delete(self, uri):
         pass  # TODO
@@ -94,40 +62,27 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
         pass  # TODO
 
 
-def on_container_loaded(sp_playlist_container):
+def playlist_lookup(web_client, uri, bitrate, as_items=False):
+    if web_client is None:
+        return
+
+    logger.info('Fetching Spotify playlist "%s"', uri)
+    web_playlist = web_client.get_playlist(uri, _cache)
+
+    if web_playlist == {}:
+        logger.error('Failed to lookup Spotify playlist URI %s', uri)
+        return
+
+    return translator.to_playlist(
+            web_playlist, username=web_client.user_id, bitrate=bitrate,
+            as_items=as_items)
+
+
+def on_playlists_loaded():
     # Called from the pyspotify event loop, and not in an actor context.
-    logger.debug('Spotify playlist container loaded')
+    logger.debug('Spotify playlists loaded')
 
     # This event listener is also called after playlists are added, removed and
     # moved, so since Mopidy currently only supports the "playlists_loaded"
     # event this is the only place we need to trigger a Mopidy backend event.
     backend.BackendListener.send('playlists_loaded')
-
-
-def on_playlist_added(sp_playlist_container, sp_playlist, index):
-    # Called from the pyspotify event loop, and not in an actor context.
-    logger.debug(
-        'Spotify playlist "%s" added to index %d', sp_playlist.name, index)
-
-    # XXX Should Mopidy support more fine grained playlist events which this
-    # event can trigger?
-
-
-def on_playlist_removed(sp_playlist_container, sp_playlist, index):
-    # Called from the pyspotify event loop, and not in an actor context.
-    logger.debug(
-        'Spotify playlist "%s" removed from index %d', sp_playlist.name, index)
-
-    # XXX Should Mopidy support more fine grained playlist events which this
-    # event can trigger?
-
-
-def on_playlist_moved(
-        sp_playlist_container, sp_playlist, old_index, new_index):
-    # Called from the pyspotify event loop, and not in an actor context.
-    logger.debug(
-        'Spotify playlist "%s" moved from index %d to %d',
-        sp_playlist.name, old_index, new_index)
-
-    # XXX Should Mopidy support more fine grained playlist events which this
-    # event can trigger?

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -17,9 +17,13 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
     def __init__(self, backend):
         self._backend = backend
         self._timeout = self._backend._config['spotify']['timeout']
+        self._loaded = False
 
     def as_list(self):
-        with utils.time_logger('playlists.as_list()'):
+        with utils.time_logger('playlists.as_list()', logging.INFO):
+            if not self._loaded:
+                return []
+
             return list(self._get_flattened_playlist_refs())
 
     def _get_flattened_playlist_refs(self):
@@ -37,11 +41,14 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
                 yield playlist_ref
 
     def get_items(self, uri):
-        with utils.time_logger('playlist.get_items(%s)' % uri):
+        with utils.time_logger('playlist.get_items(%s)' % uri, logging.INFO):
+            if not self._loaded:
+                return []
+
             return self._get_playlist(uri, as_items=True)
 
     def lookup(self, uri):
-        with utils.time_logger('playlists.lookup(%s)' % uri):
+        with utils.time_logger('playlists.lookup(%s)' % uri, logging.DEBUG):
             return self._get_playlist(uri)
 
     def _get_playlist(self, uri, as_items=False):
@@ -50,7 +57,15 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
                 self._backend._bitrate, as_items)
 
     def refresh(self):
-        pass  # TODO: Clear/invalidate all caches on refresh.
+        with utils.time_logger('Refresh Playlists', logging.INFO):
+            _cache.clear()
+            count = 0
+            playlists = self._get_flattened_playlist_refs()
+            for count, playlist_ref in enumerate(playlists, start=1):
+                self._get_playlist(playlist_ref.uri)
+            logger.info('Refreshed %d playlists', count)
+
+        self._loaded = True
 
     def create(self, name):
         pass  # TODO
@@ -66,7 +81,7 @@ def playlist_lookup(web_client, uri, bitrate, as_items=False):
     if web_client is None:
         return
 
-    logger.info('Fetching Spotify playlist "%s"', uri)
+    logger.debug('Fetching Spotify playlist "%s"', uri)
     web_playlist = web_client.get_playlist(uri, _cache)
 
     if web_playlist == {}:

--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -25,7 +25,7 @@ def search(config, session, web_client,
         return models.SearchResult(uri='spotify:search')
 
     if 'uri' in query:
-        return _search_by_uri(config, session, query)
+        return _search_by_uri(config, session, web_client, query)
 
     sp_query = translator.sp_search_query(query)
     if not sp_query:
@@ -55,7 +55,7 @@ def search(config, session, web_client,
     result = web_client.get('search', params={
         'q': sp_query,
         'limit': search_count,
-        'market': web_client.user_country,
+        'market': 'from_token',
         'type': ','.join(types)})
 
     albums = [
@@ -77,10 +77,10 @@ def search(config, session, web_client,
         uri=uri, albums=albums, artists=artists, tracks=tracks)
 
 
-def _search_by_uri(config, session, query):
+def _search_by_uri(config, session, web_client, query):
     tracks = []
     for uri in query['uri']:
-        tracks += lookup.lookup(config, session, uri)
+        tracks += lookup.lookup(config, session, web_client, uri)
 
     uri = 'spotify:search'
     if len(query['uri']) == 1:

--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -55,7 +55,7 @@ def search(config, session, web_client,
     result = web_client.get('search', params={
         'q': sp_query,
         'limit': search_count,
-        'market': session.user_country,
+        'market': web_client.user_country,
         'type': ','.join(types)})
 
     albums = [

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -150,46 +150,59 @@ def to_track_refs(sp_tracks, timeout=None):
             yield ref
 
 
-def to_playlist(
-        sp_playlist, folders=None, username=None, bitrate=None,
-        as_ref=False, as_items=False):
-    if not isinstance(sp_playlist, spotify.Playlist):
+def web_to_track_ref(web_track):
+    if web_track.get('type') != 'track':
         return
 
-    if not sp_playlist.is_loaded:
+    # TODO: Check availability
+
+    return models.Ref.track(
+        uri=web_track.get('uri'), name=web_track.get('name'))
+
+
+def web_to_track_refs(web_tracks):
+    for web_track in web_tracks:
+        ref = web_to_track_ref(web_track.get('track', {}))
+        if ref is not None:
+            yield ref
+
+
+def to_playlist(
+        web_playlist, username=None, bitrate=None,
+        as_ref=False, as_items=False):
+    if web_playlist.get('type') != 'playlist':
+        logger.error('No playlist data present')
+        return
+
+    web_tracks = web_playlist.get('tracks', {}).get('items', [])
+    if (as_items or not as_ref) and not isinstance(web_tracks, list):
+        logger.error('No playlist track data present')
         return
 
     if as_items:
-        return list(to_track_refs(sp_playlist.tracks))
+        return list(web_to_track_refs(web_tracks))
 
-    name = sp_playlist.name
+    name = web_playlist.get('name')
 
     if not as_ref:
         tracks = [
-            to_track(sp_track, bitrate=bitrate)
-            for sp_track in sp_playlist.tracks]
+            web_to_track(web_track.get('track', {}), bitrate=bitrate)
+            for web_track in web_tracks]
         tracks = filter(None, tracks)
-        if name is None:
-            # Use same starred order as the Spotify client
-            tracks = list(reversed(tracks))
 
-    if name is None:
-        name = 'Starred'
-    if folders is not None:
-        name = '/'.join(folders + [name])
-    if username is not None and sp_playlist.owner.canonical_name != username:
-        name = '%s (by %s)' % (name, sp_playlist.owner.canonical_name)
+    owner = web_playlist.get('owner', {}).get('id', username)
+    if username is not None and owner != username:
+        name = '%s (by %s)' % (name, owner)
 
     if as_ref:
-        return models.Ref.playlist(uri=sp_playlist.link.uri, name=name)
+        return models.Ref.playlist(uri=web_playlist.get('uri'), name=name)
     else:
         return models.Playlist(
-            uri=sp_playlist.link.uri, name=name, tracks=tracks)
+            uri=web_playlist.get('uri'), name=name, tracks=tracks)
 
 
-def to_playlist_ref(sp_playlist, folders=None, username=None):
-    return to_playlist(
-        sp_playlist, folders=folders, username=username, as_ref=True)
+def to_playlist_ref(web_playlist, username=None):
+    return to_playlist(web_playlist, username=username, as_ref=True)
 
 
 # Maps from Mopidy search query field to Spotify search query field.
@@ -235,29 +248,46 @@ def _transform_year(date):
 
 
 def web_to_artist(web_artist):
-    return models.Artist(uri=web_artist['uri'], name=web_artist['name'])
+    if 'uri' not in web_artist:
+        return
+
+    return models.Artist(uri=web_artist['uri'], name=web_artist.get('name'))
 
 
 def web_to_album(web_album):
+    if 'uri' not in web_album:
+        return
+
     artists = [
-        web_to_artist(web_artist) for web_artist in web_album['artists']]
+        web_to_artist(web_artist)
+        for web_artist in web_album.get('artists', [])]
+    artists = filter(None, artists)
 
     return models.Album(
         uri=web_album['uri'],
-        name=web_album['name'],
+        name=web_album.get('name'),
         artists=artists)
 
 
-def web_to_track(web_track):
+def web_to_track(web_track, bitrate=None):
+    if web_track.get('type') != 'track':
+        return
+
+    # TODO: Check availability
+
     artists = [
-        web_to_artist(web_artist) for web_artist in web_track['artists']]
-    album = web_to_album(web_track['album'])
+        web_to_artist(web_artist)
+        for web_artist in web_track.get('artists', [])]
+    artists = filter(None, artists)
+
+    album = web_to_album(web_track.get('album', {}))
 
     return models.Track(
-        uri=web_track['uri'],
-        name=web_track['name'],
+        uri=web_track.get('uri'),
+        name=web_track.get('name'),
         artists=artists,
         album=album,
-        length=web_track['duration_ms'],
-        disc_no=web_track['disc_number'],
-        track_no=web_track['track_number'])
+        length=web_track.get('duration_ms'),
+        disc_no=web_track.get('disc_number'),
+        track_no=web_track.get('track_number'),
+        bitrate=bitrate)

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -142,6 +142,10 @@ def to_track_ref(sp_track):
     return models.Ref.track(uri=sp_track.link.uri, name=sp_track.name)
 
 
+def valid_web_data(data, object_type):
+    return data.get('type') == object_type and 'uri' in data
+
+
 def to_track_refs(sp_tracks, timeout=None):
     for sp_track in sp_tracks:
         sp_track.load(timeout)
@@ -151,13 +155,18 @@ def to_track_refs(sp_tracks, timeout=None):
 
 
 def web_to_track_ref(web_track):
-    if web_track.get('type') != 'track':
+    if not valid_web_data(web_track, 'track'):
         return
 
-    # TODO: Check availability
+    # Web API track relinking guide says to use original URI.
+    # libspotfy will handle any relinking when track is loaded for playback.
+    uri = web_track.get('linked_from', {}).get('uri') or web_track['uri']
 
-    return models.Ref.track(
-        uri=web_track.get('uri'), name=web_track.get('name'))
+    if not web_track.get('is_playable', False):
+        logger.warning('%s is not playable', uri)
+        return
+
+    return models.Ref.track(uri=uri, name=web_track.get('name'))
 
 
 def web_to_track_refs(web_tracks):
@@ -170,13 +179,11 @@ def web_to_track_refs(web_tracks):
 def to_playlist(
         web_playlist, username=None, bitrate=None,
         as_ref=False, as_items=False):
-    if web_playlist.get('type') != 'playlist':
-        logger.error('No playlist data present')
+    if not valid_web_data(web_playlist, 'playlist'):
         return
 
     web_tracks = web_playlist.get('tracks', {}).get('items', [])
     if (as_items or not as_ref) and not isinstance(web_tracks, list):
-        logger.error('No playlist track data present')
         return
 
     if as_items:
@@ -195,10 +202,10 @@ def to_playlist(
         name = '%s (by %s)' % (name, owner)
 
     if as_ref:
-        return models.Ref.playlist(uri=web_playlist.get('uri'), name=name)
+        return models.Ref.playlist(uri=web_playlist['uri'], name=name)
     else:
         return models.Playlist(
-            uri=web_playlist.get('uri'), name=name, tracks=tracks)
+            uri=web_playlist['uri'], name=name, tracks=tracks)
 
 
 def to_playlist_ref(web_playlist, username=None):
@@ -248,14 +255,14 @@ def _transform_year(date):
 
 
 def web_to_artist(web_artist):
-    if 'uri' not in web_artist:
+    if not valid_web_data(web_artist, 'artist'):
         return
 
     return models.Artist(uri=web_artist['uri'], name=web_artist.get('name'))
 
 
 def web_to_album(web_album):
-    if 'uri' not in web_album:
+    if not valid_web_data(web_album, 'album'):
         return
 
     artists = [
@@ -270,10 +277,9 @@ def web_to_album(web_album):
 
 
 def web_to_track(web_track, bitrate=None):
-    if web_track.get('type') != 'track':
+    ref = web_to_track_ref(web_track)
+    if ref is None:
         return
-
-    # TODO: Check availability
 
     artists = [
         web_to_artist(web_artist)
@@ -283,8 +289,8 @@ def web_to_track(web_track, bitrate=None):
     album = web_to_album(web_track.get('album', {}))
 
     return models.Track(
-        uri=web_track.get('uri'),
-        name=web_track.get('name'),
+        uri=ref.uri,
+        name=ref.name,
         artists=artists,
         album=album,
         length=web_track.get('duration_ms'),

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -163,7 +163,7 @@ def web_to_track_ref(web_track):
     uri = web_track.get('linked_from', {}).get('uri') or web_track['uri']
 
     if not web_track.get('is_playable', False):
-        logger.warning('%s is not playable', uri)
+        logger.debug('%s is not playable', uri)
         return
 
     return models.Ref.track(uri=uri, name=web_track.get('name'))

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -335,8 +335,8 @@ class WebResponse(dict):
         return True
 
     def __str__(self):
-        return 'URL: %s ETag: %s Expires: %s' % (
-            self.url, self._etag, datetime.fromtimestamp(self._expires))
+        return 'URL: %s expires at %s [ETag: %s]' % (
+            self.url, datetime.fromtimestamp(self._expires), self._etag)
 
 
 class SpotifyOAuthClient(OAuthClient):

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -335,3 +335,26 @@ class WebResponse(dict):
     def __str__(self):
         return 'URL: %s ETag: %s Expires: %s' % (
             self.url, self._etag, datetime.fromtimestamp(self._expires))
+
+
+class SpotifyOAuthClient(OAuthClient):
+
+    def __init__(self, client_id, client_secret, proxy_config):
+        self.user_name = None
+        self.user_country = None
+        super(SpotifyOAuthClient, self).__init__(
+            base_url='https://api.spotify.com/v1',
+            refresh_url='https://auth.mopidy.com/spotify/token',
+            client_id=client_id, client_secret=client_secret,
+            proxy_config=proxy_config)
+
+    def login(self):
+        user_profile = self.get('me')
+        if user_profile is None:
+            logger.error('Failed to load Spotify user profile')
+            return False
+        else:
+            self.user_name = user_profile.get('id')
+            self.user_country = user_profile.get('country')
+            logger.info('Logged into Spotify Web API as %s', self.user_name)
+            return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -396,7 +396,9 @@ def session_mock():
 
 @pytest.fixture
 def web_client_mock():
-    web_client_mock = mock.Mock(spec=web.OAuthClient)
+    web_client_mock = mock.Mock(spec=web.SpotifyOAuthClient)
+    web_client_mock.user_name = 'Jane Doe'
+    web_client_mock.user_country = 'GB'
     return web_client_mock
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -326,7 +326,8 @@ def web_search_mock_large(
 def web_artist_mock():
     return {
         'name': 'ABBA',
-        'uri': 'spotify:artist:abba'
+        'uri': 'spotify:artist:abba',
+        'type': 'artist'
     }
 
 
@@ -335,6 +336,7 @@ def web_album_mock(web_artist_mock):
     return {
         'name': 'DEF 456',
         'uri': 'spotify:album:def',
+        'type': 'album',
         'artists': [web_artist_mock]
     }
 
@@ -350,6 +352,7 @@ def web_track_mock(web_artist_mock, web_album_mock):
         'track_number': 7,
         'uri': 'spotify:track:abc',
         'type': 'track',
+        'is_playable': True,
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,14 @@ def config(tmpdir):
 
 
 @pytest.yield_fixture
-def spotify_mock():
+def web_mock():
+    patcher = mock.patch.object(backend, 'web', spec=web)
+    yield patcher.start()
+    patcher.stop()
+
+
+@pytest.yield_fixture
+def spotify_mock(web_mock):
     patcher = mock.patch.object(backend, 'spotify', spec=spotify)
     yield patcher.start()
     patcher.stop()
@@ -342,6 +349,7 @@ def web_track_mock(web_artist_mock, web_album_mock):
         'name': 'ABC 123',
         'track_number': 7,
         'uri': 'spotify:track:abc',
+        'type': 'track',
     }
 
 
@@ -370,6 +378,22 @@ def web_oauth_mock():
 
 
 @pytest.fixture
+def web_playlist_mock(web_track_mock):
+    return {
+        'owner': {
+            'id': 'alice',
+        },
+        'name': 'Foo',
+        'tracks': {
+            'items': [{'track': web_track_mock}]
+        },
+        'snapshot_id': 'abcderfg12364',
+        'uri': 'spotify:user:alice:playlist:foo',
+        'type': 'playlist',
+    }
+
+
+@pytest.fixture
 def mopidy_artist_mock():
     return models.Artist(
         name='ABBA',
@@ -389,16 +413,14 @@ def mopidy_album_mock(mopidy_artist_mock):
 def session_mock():
     sp_session_mock = mock.Mock(spec=spotify.Session)
     sp_session_mock.connection.state = spotify.ConnectionState.LOGGED_IN
-    sp_session_mock.playlist_container = []
-    sp_session_mock.user_country = 'GB'
     return sp_session_mock
 
 
 @pytest.fixture
 def web_client_mock():
     web_client_mock = mock.Mock(spec=web.SpotifyOAuthClient)
-    web_client_mock.user_name = 'Jane Doe'
-    web_client_mock.user_country = 'GB'
+    web_client_mock.user_id = 'alice'
+    web_client_mock.get_user_playlists.return_value = []
     return web_client_mock
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -18,6 +18,7 @@ def get_backend(config, session_mock=None):
     else:
         obj._session = mock.Mock()
         obj._session.playlist_container = None
+        obj._web_client = mock.Mock()
     obj._event_loop = mock.Mock()
     return obj
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -181,6 +181,27 @@ def test_on_start_logs_in(spotify_mock, web_mock, config):
     web_mock.SpotifyOAuthClient.return_value.login.assert_called_once()
 
 
+def test_on_start_refreshes_playlists(spotify_mock, web_mock, config, caplog):
+    backend = get_backend(config)
+    backend.on_start()
+
+    client_mock = web_mock.SpotifyOAuthClient.return_value
+    client_mock.get_user_playlists.assert_called_once()
+    assert 'Refreshed 0 playlists' in caplog.text
+
+
+def test_on_start_doesnt_refresh_playlists_if_not_allowed(
+        spotify_mock, web_mock, config, caplog):
+    config['spotify']['allow_playlists'] = False
+
+    backend = get_backend(config)
+    backend.on_start()
+
+    client_mock = web_mock.SpotifyOAuthClient.return_value
+    client_mock.get_user_playlists.assert_not_called()
+    assert 'Refreshed 0 playlists' not in caplog.text
+
+
 def test_on_stop_logs_out_and_waits_for_logout_to_complete(
         spotify_mock, config, caplog):
     backend = get_backend(config)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -188,6 +188,7 @@ def test_on_start_refreshes_playlists(spotify_mock, web_mock, config, caplog):
     client_mock = web_mock.SpotifyOAuthClient.return_value
     client_mock.get_user_playlists.assert_called_once()
     assert 'Refreshed 0 playlists' in caplog.text
+    assert backend.playlists._loaded
 
 
 def test_on_start_doesnt_refresh_playlists_if_not_allowed(

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -155,12 +155,14 @@ def test_lookup_of_artist_uri_ignores_various_artists_albums(
 
 
 def test_lookup_of_playlist_uri(
-        session_mock, web_client_mock, web_playlist_mock, provider):
+        session_mock, web_client_mock, web_playlist_mock, sp_track_mock,
+        provider):
     web_client_mock.get_playlist.return_value = web_playlist_mock
+    session_mock.get_link.return_value = sp_track_mock.link
 
     results = provider.lookup('spotify:playlist:alice:foo')
 
-    session_mock.get_link.assert_not_called()
+    session_mock.get_link.assert_called_once_with('spotify:track:abc')
     web_client_mock.get_playlist.assert_called_once_with(
         'spotify:playlist:alice:foo', {})
 

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -164,10 +164,23 @@ def test_lookup_of_playlist_uri(
 
     session_mock.get_link.assert_called_once_with('spotify:track:abc')
     web_client_mock.get_playlist.assert_called_once_with(
-        'spotify:playlist:alice:foo', {})
+        'spotify:playlist:alice:foo')
 
     assert len(results) == 1
     track = results[0]
     assert track.uri == 'spotify:track:abc'
     assert track.name == 'ABC 123'
     assert track.bitrate == 160
+
+
+def test_lookup_of_playlist_uri_when_not_logged_in(
+        web_client_mock, provider, caplog):
+    web_client_mock.user_id = None
+
+    results = provider.lookup('spotify:playlist:alice:foo')
+
+    assert len(results) == 0
+    assert (
+        'Failed to lookup "spotify:playlist:alice:foo": '
+        'Playlist Web API lookup failed'
+        in caplog.text)

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -1,58 +1,58 @@
 from __future__ import unicode_literals
 
-import mock
-
 from mopidy import backend as backend_api
 from mopidy.models import Ref
 
 import pytest
 
-import spotify
-
-from mopidy_spotify import backend, playlists
+from mopidy_spotify import playlists
 
 
 @pytest.fixture
-def session_mock(
-        sp_playlist_mock,
-        sp_playlist_folder_start_mock, sp_playlist_folder_end_mock,
-        sp_user_mock):
+def web_client_mock(web_client_mock, web_track_mock):
+    web_playlist1 = {
+        'owner': {
+            'id': 'alice',
+        },
+        'name': 'Foo',
+        'tracks': {
+            'items': [{'track': web_track_mock}]
+        },
+        'uri': 'spotify:user:alice:playlist:foo',
+        'type': 'playlist',
+    }
+    web_playlist2 = {
+        'owner': {
+            'id': 'bob',
+        },
+        'name': 'Baz',
+        'uri': 'spotify:user:bob:playlist:baz',
+        'type': 'playlist',
+    }
+    web_playlist3 = {
+        'owner': {
+            'id': 'alice',
+        },
+        'name': 'Malformed',
+        'tracks': {
+            'items': []
+        },
+        'uri': 'spotify:user:alice:playlist:malformed',
+    }
+    web_playlists = [web_playlist1, web_playlist2, web_playlist3]
+    web_playlists_map = {x['uri']: x for x in web_playlists}
 
-    sp_playlist2_mock = mock.Mock(spec=spotify.Playlist)
-    sp_playlist2_mock.is_loaded = True
-    sp_playlist2_mock.owner = mock.Mock(spec=spotify.User)
-    sp_playlist2_mock.owner.canonical_name = 'bob'
-    sp_playlist2_mock.link.uri = 'spotify:playlist:bob:baz'
-    sp_playlist2_mock.name = 'Baz'
-    sp_playlist2_mock.tracks = []
+    def get_playlist(*args, **kwargs):
+        return web_playlists_map.get(args[0], {})
 
-    sp_playlist3_mock = mock.Mock(spec=spotify.Playlist)
-    sp_playlist3_mock.is_loaded = False
-
-    sp_session_mock = mock.Mock(spec=spotify.Session)
-    sp_session_mock.user = sp_user_mock
-    sp_session_mock.user_name = 'alice'
-    sp_session_mock.playlist_container = [
-        sp_playlist_mock,
-        sp_playlist_folder_start_mock,
-        sp_playlist2_mock,
-        sp_playlist_folder_end_mock,
-        sp_playlist3_mock,
-    ]
-    return sp_session_mock
+    web_client_mock.get_user_playlists.return_value = web_playlists
+    web_client_mock.get_playlist.side_effect = get_playlist
+    return web_client_mock
 
 
 @pytest.fixture
-def backend_mock(session_mock, config):
-    backend_mock = mock.Mock(spec=backend.SpotifyBackend)
-    backend_mock._config = config
-    backend_mock._session = session_mock
-    backend_mock._bitrate = 160
-    return backend_mock
-
-
-@pytest.fixture
-def provider(backend_mock):
+def provider(backend_mock, web_client_mock):
+    backend_mock._web_client = web_client_mock
     return playlists.SpotifyPlaylistsProvider(backend_mock)
 
 
@@ -60,32 +60,23 @@ def test_is_a_playlists_provider(provider):
     assert isinstance(provider, backend_api.PlaylistsProvider)
 
 
-def test_as_list_when_not_logged_in(
-        session_mock, provider):
-    session_mock.playlist_container = None
+def test_as_list_when_not_logged_in(web_client_mock, provider):
+    web_client_mock.user_id = None
 
     result = provider.as_list()
 
     assert len(result) == 0
 
 
-def test_as_list_when_offline(session_mock, provider):
-    session_mock.connection.state = spotify.ConnectionState.OFFLINE
-
-    result = provider.as_list()
-
-    assert len(result) == 2
-
-
-def test_as_list_when_playlist_container_isnt_loaded(session_mock, provider):
-    session_mock.playlist_container = None
+def test_as_list_when_offline(web_client_mock, provider):
+    web_client_mock.get_user_playlists.return_value = {}
 
     result = provider.as_list()
 
     assert len(result) == 0
 
 
-def test_as_list_with_folders_and_ignored_unloaded_playlist(provider):
+def test_as_list_when_playlist_malformed(provider, caplog):
     result = provider.as_list()
 
     assert len(result) == 2
@@ -93,13 +84,19 @@ def test_as_list_with_folders_and_ignored_unloaded_playlist(provider):
     assert result[0] == Ref.playlist(
         uri='spotify:user:alice:playlist:foo', name='Foo')
     assert result[1] == Ref.playlist(
-        uri='spotify:playlist:bob:baz', name='Bar/Baz (by bob)')
+        uri='spotify:user:bob:playlist:baz', name='Baz (by bob)')
+
+    assert 'No playlist data present' in caplog.text
 
 
-def test_get_items_when_playlist_exists(
-        session_mock, sp_playlist_mock, provider):
-    session_mock.get_playlist.return_value = sp_playlist_mock
+def test_as_list_uses_cache(provider, web_client_mock):
+    provider.as_list()
 
+    web_client_mock.get_user_playlists.assert_called_once_with(
+        playlists._cache)
+
+
+def test_get_items_when_playlist_exists(provider):
     result = provider.get_items('spotify:user:alice:playlist:foo')
 
     assert len(result) == 1
@@ -107,15 +104,34 @@ def test_get_items_when_playlist_exists(
     assert result[0] == Ref.track(uri='spotify:track:abc', name='ABC 123')
 
 
-def test_get_items_when_playlist_is_unknown(provider):
-    result = provider.get_items('spotify:user:alice:playlist:unknown')
+def test_get_items_when_playlist_without_tracks(provider):
+    result = provider.get_items('spotify:user:bob:playlist:baz')
 
-    assert result is None
+    assert len(result) == 0
+
+    assert result == []
 
 
-def test_lookup(session_mock, sp_playlist_mock, provider):
-    session_mock.get_playlist.return_value = sp_playlist_mock
+def test_get_items_when_playlist_is_malformed(provider, caplog):
+    assert provider.get_items('spotify:user:alice:playlist:malformed') is None
+    assert 'No playlist data present' in caplog.text
 
+
+def test_get_items_when_playlist_is_unknown(provider, caplog):
+    assert provider.get_items('spotify:user:alice:playlist:unknown') is None
+    assert (
+        'Failed to lookup Spotify playlist URI '
+        'spotify:user:alice:playlist:unknown' in caplog.text)
+
+
+def test_as_get_items_uses_cache(provider, web_client_mock):
+    provider.get_items('spotify:user:alice:playlist:foo')
+
+    web_client_mock.get_playlist.assert_called_once_with(
+        'spotify:user:alice:playlist:foo', playlists._cache)
+
+
+def test_lookup(provider):
     playlist = provider.lookup('spotify:user:alice:playlist:foo')
 
     assert playlist.uri == 'spotify:user:alice:playlist:foo'
@@ -123,111 +139,28 @@ def test_lookup(session_mock, sp_playlist_mock, provider):
     assert playlist.tracks[0].bitrate == 160
 
 
-def test_lookup_loads_playlist_when_a_playlist_isnt_loaded(
-        sp_playlist_mock, session_mock, provider):
-    is_loaded_mock = mock.PropertyMock()
-    type(sp_playlist_mock).is_loaded = is_loaded_mock
-    is_loaded_mock.side_effect = [False, True]
-    session_mock.get_playlist.return_value = sp_playlist_mock
-
-    playlist = provider.lookup('spotify:user:alice:playlist:foo')
-
-    sp_playlist_mock.load.assert_called_once_with(10)
-    assert playlist.uri == 'spotify:user:alice:playlist:foo'
-    assert playlist.name == 'Foo'
+def test_lookup_when_playlist_is_empty(provider, caplog):
+    assert provider.lookup('nothing') is None
+    assert 'Failed to lookup Spotify playlist URI nothing' in caplog.text
 
 
-def test_lookup_when_playlist_is_unknown(session_mock, provider):
-    session_mock.get_playlist.side_effect = spotify.Error
+def test_lookup_of_playlist_with_other_owner(provider):
+    playlist = provider.lookup('spotify:user:bob:playlist:baz')
 
-    assert provider.lookup('foo') is None
-
-
-def test_lookup_of_playlist_with_other_owner(
-        session_mock, sp_user_mock, sp_playlist_mock, provider):
-    sp_user_mock.canonical_name = 'bob'
-    sp_playlist_mock.owner = sp_user_mock
-    session_mock.get_playlist.return_value = sp_playlist_mock
-
-    playlist = provider.lookup('spotify:user:alice:playlist:foo')
-
-    assert playlist.uri == 'spotify:user:alice:playlist:foo'
-    assert playlist.name == 'Foo (by bob)'
+    assert playlist.uri == 'spotify:user:bob:playlist:baz'
+    assert playlist.name == 'Baz (by bob)'
 
 
-def test_create(session_mock, sp_playlist_mock, provider):
-    session_mock.playlist_container = mock.Mock(
-        spec=spotify.PlaylistContainer)
-    session_mock.playlist_container.add_new_playlist.return_value = (
-        sp_playlist_mock)
+def test_lookup_uses_cache(provider, web_client_mock):
+    provider.lookup('spotify:user:alice:playlist:foo')
 
-    playlist = provider.create('Foo')
-
-    session_mock.playlist_container.add_new_playlist.assert_called_once_with(
-        'Foo')
-    assert playlist.uri == 'spotify:user:alice:playlist:foo'
-    assert playlist.name == 'Foo'
+    web_client_mock.get_playlist.assert_called_once_with(
+        'spotify:user:alice:playlist:foo', playlists._cache)
 
 
-def test_create_with_invalid_name(session_mock, provider, caplog):
-    session_mock.playlist_container = mock.Mock(
-        spec=spotify.PlaylistContainer)
-    session_mock.playlist_container.add_new_playlist.side_effect = ValueError(
-        'Too long name')
+def test_on_playlists_loaded_triggers_playlists_loaded_event(
+        caplog, backend_listener_mock):
+    playlists.on_playlists_loaded()
 
-    playlist = provider.create('Foo')
-
-    assert playlist is None
-    assert (
-        'Failed creating new Spotify playlist "Foo": Too long name'
-        in caplog.text)
-
-
-def test_create_fails_in_libspotify(session_mock, provider, caplog):
-    session_mock.playlist_container = mock.Mock(
-        spec=spotify.PlaylistContainer)
-    session_mock.playlist_container.add_new_playlist.side_effect = (
-        spotify.Error)
-
-    playlist = provider.create('Foo')
-
-    assert playlist is None
-    assert 'Failed creating new Spotify playlist "Foo"' in caplog.text
-
-
-def test_on_container_loaded_triggers_playlists_loaded_event(
-        sp_playlist_container_mock, caplog, backend_listener_mock):
-    playlists.on_container_loaded(sp_playlist_container_mock)
-
-    assert 'Spotify playlist container loaded' in caplog.text
+    assert 'Spotify playlists loaded' in caplog.text
     backend_listener_mock.send.assert_called_once_with('playlists_loaded')
-
-
-def test_on_playlist_added_does_nothing_yet(
-        sp_playlist_container_mock, sp_playlist_mock,
-        caplog, backend_listener_mock):
-    playlists.on_playlist_added(
-        sp_playlist_container_mock, sp_playlist_mock, 0)
-
-    assert 'Spotify playlist "Foo" added to index 0' in caplog.text
-    assert backend_listener_mock.send.call_count == 0
-
-
-def test_on_playlist_removed_does_nothing_yet(
-        sp_playlist_container_mock, sp_playlist_mock,
-        caplog, backend_listener_mock):
-    playlists.on_playlist_removed(
-        sp_playlist_container_mock, sp_playlist_mock, 0)
-
-    assert 'Spotify playlist "Foo" removed from index 0' in caplog.text
-    assert backend_listener_mock.send.call_count == 0
-
-
-def test_on_playlist_moved_does_nothing_yet(
-        sp_playlist_container_mock, sp_playlist_mock,
-        caplog, backend_listener_mock):
-    playlists.on_playlist_moved(
-        sp_playlist_container_mock, sp_playlist_mock, 0, 1)
-
-    assert 'Spotify playlist "Foo" moved from index 0 to 1' in caplog.text
-    assert backend_listener_mock.send.call_count == 0

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -38,6 +38,7 @@ def web_client_mock(web_client_mock, web_track_mock):
             'items': []
         },
         'uri': 'spotify:user:alice:playlist:malformed',
+        'type': 'bogus',
     }
     web_playlists = [web_playlist1, web_playlist2, web_playlist3]
     web_playlists_map = {x['uri']: x for x in web_playlists}
@@ -76,7 +77,7 @@ def test_as_list_when_offline(web_client_mock, provider):
     assert len(result) == 0
 
 
-def test_as_list_when_playlist_malformed(provider, caplog):
+def test_as_list_when_playlist_wont_translate(provider, caplog):
     result = provider.as_list()
 
     assert len(result) == 2
@@ -85,8 +86,6 @@ def test_as_list_when_playlist_malformed(provider, caplog):
         uri='spotify:user:alice:playlist:foo', name='Foo')
     assert result[1] == Ref.playlist(
         uri='spotify:user:bob:playlist:baz', name='Baz (by bob)')
-
-    assert 'No playlist data present' in caplog.text
 
 
 def test_as_list_uses_cache(provider, web_client_mock):
@@ -112,9 +111,8 @@ def test_get_items_when_playlist_without_tracks(provider):
     assert result == []
 
 
-def test_get_items_when_playlist_is_malformed(provider, caplog):
+def test_get_items_when_playlist_wont_translate(provider, caplog):
     assert provider.get_items('spotify:user:alice:playlist:malformed') is None
-    assert 'No playlist data present' in caplog.text
 
 
 def test_get_items_when_playlist_is_unknown(provider, caplog):

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import mock
+
 from mopidy import backend as backend_api
 from mopidy.models import Ref
 
@@ -54,7 +56,9 @@ def web_client_mock(web_client_mock, web_track_mock):
 @pytest.fixture
 def provider(backend_mock, web_client_mock):
     backend_mock._web_client = web_client_mock
-    return playlists.SpotifyPlaylistsProvider(backend_mock)
+    provider = playlists.SpotifyPlaylistsProvider(backend_mock)
+    provider._loaded = True
+    return provider
 
 
 def test_is_a_playlists_provider(provider):
@@ -71,6 +75,14 @@ def test_as_list_when_not_logged_in(web_client_mock, provider):
 
 def test_as_list_when_offline(web_client_mock, provider):
     web_client_mock.get_user_playlists.return_value = {}
+
+    result = provider.as_list()
+
+    assert len(result) == 0
+
+
+def test_as_list_blocked_when_not_loaded(provider):
+    provider._loaded = False
 
     result = provider.as_list()
 
@@ -111,6 +123,16 @@ def test_get_items_when_playlist_without_tracks(provider):
     assert result == []
 
 
+def test_get_items_blocked_when_not_loaded(provider):
+    provider._loaded = False
+
+    result = provider.get_items('spotify:user:alice:playlist:foo')
+
+    assert len(result) == 0
+
+    assert result == []
+
+
 def test_get_items_when_playlist_wont_translate(provider, caplog):
     assert provider.get_items('spotify:user:alice:playlist:malformed') is None
 
@@ -122,11 +144,40 @@ def test_get_items_when_playlist_is_unknown(provider, caplog):
         'spotify:user:alice:playlist:unknown' in caplog.text)
 
 
-def test_as_get_items_uses_cache(provider, web_client_mock):
-    provider.get_items('spotify:user:alice:playlist:foo')
+def test_refresh_loads_all_playlists(provider, web_client_mock):
+    provider.refresh()
 
-    web_client_mock.get_playlist.assert_called_once_with(
-        'spotify:user:alice:playlist:foo', playlists._cache)
+    web_client_mock.get_user_playlists.assert_called_once()
+    assert web_client_mock.get_playlist.call_count == 2
+    expected_calls = [
+        mock.call('spotify:user:alice:playlist:foo', {}),
+        mock.call('spotify:user:bob:playlist:baz', {}),
+    ]
+    web_client_mock.get_playlist.assert_has_calls(expected_calls)
+
+
+def test_refresh_when_not_loaded(provider, web_client_mock):
+    provider._loaded = False
+
+    provider.refresh()
+
+    web_client_mock.get_user_playlists.assert_called_once()
+    web_client_mock.get_playlist.assert_called()
+    assert provider._loaded
+
+
+def test_refresh_counts_playlists(provider, caplog):
+    provider.refresh()
+
+    assert 'Refreshed 2 playlists' in caplog.text
+
+
+def test_refresh_clears_web_cache(provider):
+    playlists._cache = {'foo': 'foobar', 'foo2': 'foofoo'}
+
+    provider.refresh()
+
+    assert len(playlists._cache) == 0
 
 
 def test_lookup(provider):
@@ -135,6 +186,15 @@ def test_lookup(provider):
     assert playlist.uri == 'spotify:user:alice:playlist:foo'
     assert playlist.name == 'Foo'
     assert playlist.tracks[0].bitrate == 160
+
+
+def test_lookup_when_not_loaded(provider):
+    provider._loaded = False
+
+    playlist = provider.lookup('spotify:user:alice:playlist:foo')
+
+    assert playlist.uri == 'spotify:user:alice:playlist:foo'
+    assert playlist.name == 'Foo'
 
 
 def test_lookup_when_playlist_is_empty(provider, caplog):

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -58,7 +58,6 @@ def web_client_mock(web_client_mock, web_track_mock):
 @pytest.fixture
 def provider(backend_mock, web_client_mock):
     backend_mock._web_client = web_client_mock
-    playlists._cache.clear()
     playlists._sp_links.clear()
     provider = playlists.SpotifyPlaylistsProvider(backend_mock)
     provider._loaded = True
@@ -104,13 +103,6 @@ def test_as_list_when_playlist_wont_translate(provider, caplog):
         uri='spotify:user:bob:playlist:baz', name='Baz (by bob)')
 
 
-def test_as_list_uses_cache(provider, web_client_mock):
-    provider.as_list()
-
-    web_client_mock.get_user_playlists.assert_called_once_with(
-        playlists._cache)
-
-
 def test_get_items_when_playlist_exists(provider):
     result = provider.get_items('spotify:user:alice:playlist:foo')
 
@@ -154,8 +146,8 @@ def test_refresh_loads_all_playlists(provider, web_client_mock):
     web_client_mock.get_user_playlists.assert_called_once()
     assert web_client_mock.get_playlist.call_count == 2
     expected_calls = [
-        mock.call('spotify:user:alice:playlist:foo', {}),
-        mock.call('spotify:user:bob:playlist:baz', {}),
+        mock.call('spotify:user:alice:playlist:foo'),
+        mock.call('spotify:user:bob:playlist:baz'),
     ]
     web_client_mock.get_playlist.assert_has_calls(expected_calls)
 
@@ -176,12 +168,15 @@ def test_refresh_counts_playlists(provider, caplog):
     assert 'Refreshed 2 playlists' in caplog.text
 
 
-def test_refresh_clears_web_cache(provider):
-    playlists._cache = {'foo': 'foobar', 'foo2': 'foofoo'}
+def test_refresh_clears_web_cache(provider, web_client_mock):
+    # provider._backend._web_client._cache = {
+        # 'foo': 'foobar', 'foo2': 'foofoo'}
 
     provider.refresh()
 
-    assert len(playlists._cache) == 0
+    web_client_mock.clear_data.assert_called()
+
+    # assert len(playlists._cache) == 0
 
 
 def test_refresh_clears_link_cache(provider):
@@ -286,14 +281,6 @@ def test_playlist_lookup_when_link_invalid(
 
     assert len(playlist.tracks) == 1
     assert 'Failed to get link "spotify:track:abc"' in caplog.text
-
-
-def test_playlist_lookup_uses_cache(session_mock, web_client_mock):
-    playlists.playlist_lookup(
-        session_mock, web_client_mock, 'spotify:user:alice:playlist:foo', None)
-
-    web_client_mock.get_playlist.assert_called_once_with(
-        'spotify:user:alice:playlist:foo', playlists._cache)
 
 
 def test_on_playlists_loaded_triggers_playlists_loaded_event(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -77,7 +77,7 @@ def test_search_returns_albums_and_artists_and_tracks(
         params={
             'q': '"ABBA"',
             'limit': 50,
-            'market': 'GB',
+            'market': 'from_token',
             'type': 'album,artist,track'})
 
     assert 'Searching Spotify for: "ABBA"' in caplog.text
@@ -125,7 +125,7 @@ def test_sets_api_limit_to_album_count_when_max(
         params={
             'q': '"ABBA"',
             'limit': 6,
-            'market': 'GB',
+            'market': 'from_token',
             'type': 'album,artist,track'})
 
     assert len(result.albums) == 6
@@ -146,7 +146,7 @@ def test_sets_api_limit_to_artist_count_when_max(
         params={
             'q': '"ABBA"',
             'limit': 6,
-            'market': 'GB',
+            'market': 'from_token',
             'type': 'album,artist,track'})
 
     assert len(result.artists) == 6
@@ -167,7 +167,7 @@ def test_sets_api_limit_to_track_count_when_max(
         params={
             'q': '"ABBA"',
             'limit': 6,
-            'market': 'GB',
+            'market': 'from_token',
             'type': 'album,artist,track'})
 
     assert len(result.tracks) == 6
@@ -187,13 +187,12 @@ def test_sets_types_parameter(
         params={
             'q': '"ABBA"',
             'limit': 50,
-            'market': 'GB',
+            'market': 'from_token',
             'type': 'album,artist'})
 
 
-def test_sets_market_parameter_from_user_country(
+def test_sets_market_parameter(
         web_client_mock, web_search_mock_large, provider):
-    web_client_mock.user_country = 'SE'
     web_client_mock.get.return_value = web_search_mock_large
 
     provider.search({'any': ['ABBA']})
@@ -203,7 +202,7 @@ def test_sets_market_parameter_from_user_country(
         params={
             'q': '"ABBA"',
             'limit': 50,
-            'market': 'SE',
+            'market': 'from_token',
             'type': 'album,artist,track'})
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -192,8 +192,8 @@ def test_sets_types_parameter(
 
 
 def test_sets_market_parameter_from_user_country(
-        web_client_mock, web_search_mock_large, provider, session_mock):
-    session_mock.user_country = 'SE'
+        web_client_mock, web_search_mock_large, provider):
+    web_client_mock.user_country = 'SE'
     web_client_mock.get.return_value = web_search_mock_large
 
     provider.search({'any': ['ABBA']})

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import mock
-
 from mopidy import models
 
 import spotify
@@ -246,26 +244,49 @@ class TestToTrackRef(object):
         assert ref1 is ref2
 
 
+class TestWebToTrackRef(object):
+
+    def test_returns_none_if_unloaded(self):
+        web_track_mock = {}
+
+        ref = translator.web_to_track_ref(web_track_mock)
+
+        assert ref is None
+
+    def test_returns_none_if_wrong_type(self, web_track_mock):
+        web_track_mock['type'] = 'playlist'
+
+        ref = translator.web_to_track_ref(web_track_mock)
+
+        assert ref is None
+
+    def test_successful_translation(self, web_track_mock):
+        ref = translator.web_to_track_ref(web_track_mock)
+
+        assert ref.type == models.Ref.TRACK
+        assert ref.uri == 'spotify:track:abc'
+        assert ref.name == 'ABC 123'
+
+
 class TestToPlaylist(object):
 
     def test_returns_none_if_unloaded(self):
-        sp_playlist = mock.Mock(spec=spotify.Playlist)
-        sp_playlist.is_loaded = False
+        web_playlist = {}
 
-        playlist = translator.to_playlist(sp_playlist)
-
-        assert playlist is None
-
-    def test_returns_none_if_playlist_folder(self):
-        sp_playlist_folder = mock.Mock(spec=spotify.PlaylistFolder)
-
-        playlist = translator.to_playlist(sp_playlist_folder)
+        playlist = translator.to_playlist(web_playlist)
 
         assert playlist is None
 
-    def test_successful_translation(self, sp_track_mock, sp_playlist_mock):
-        track = translator.to_track(sp_track_mock)
-        playlist = translator.to_playlist(sp_playlist_mock)
+    def test_returns_none_if_wrong_type(self, web_playlist_mock):
+        web_playlist_mock['type'] = 'track'
+
+        playlist = translator.to_playlist(web_playlist_mock)
+
+        assert playlist is None
+
+    def test_successful_translation(self, web_track_mock, web_playlist_mock):
+        track = translator.web_to_track(web_track_mock)
+        playlist = translator.to_playlist(web_playlist_mock)
 
         assert playlist.uri == 'spotify:user:alice:playlist:foo'
         assert playlist.name == 'Foo'
@@ -273,43 +294,40 @@ class TestToPlaylist(object):
         assert track in playlist.tracks
         assert playlist.last_modified is None
 
-    def test_as_items(self, sp_track_mock, sp_playlist_mock):
-        track_ref = translator.to_track_ref(sp_track_mock)
-        items = translator.to_playlist(sp_playlist_mock, as_items=True)
+    def test_no_track_data(self, web_playlist_mock):
+        del web_playlist_mock['tracks']
+
+        playlist = translator.to_playlist(web_playlist_mock)
+
+        assert playlist.uri == 'spotify:user:alice:playlist:foo'
+        assert playlist.name == 'Foo'
+        assert playlist.length == 0
+
+    def test_as_items(self, web_track_mock, web_playlist_mock):
+        track_ref = translator.web_to_track_ref(web_track_mock)
+        items = translator.to_playlist(web_playlist_mock, as_items=True)
 
         assert track_ref in items
 
-    def test_adds_name_for_starred_playlists(self, sp_starred_mock):
-        playlist = translator.to_playlist(sp_starred_mock)
+    def test_as_items_no_track_data(self, web_playlist_mock):
+        del web_playlist_mock['tracks']
 
-        assert playlist.name == 'Starred'
+        items = translator.to_playlist(web_playlist_mock, as_items=True)
 
-    def test_reorders_starred_playlists(self, sp_starred_mock):
-        playlist = translator.to_playlist(sp_starred_mock)
-
-        assert len(playlist.tracks) == 2
-        assert playlist.tracks[0].name == 'Newest'
-        assert playlist.tracks[1].name == 'Oldest'
+        assert len(items) == 0
 
     def test_includes_by_owner_in_name_if_owned_by_another_user(
-            self, sp_playlist_mock, sp_user_mock):
-        sp_user_mock.canonical_name = 'bob'
-        sp_playlist_mock.user = sp_user_mock
+            self, web_playlist_mock):
+        web_playlist_mock['owner']['id'] = 'bob'
 
-        playlist = translator.to_playlist(sp_playlist_mock, username='alice')
+        playlist = translator.to_playlist(web_playlist_mock, username='alice')
 
         assert playlist.name == 'Foo (by bob)'
 
-    def test_includes_folders_in_name(self, sp_playlist_mock):
-        playlist = translator.to_playlist(
-            sp_playlist_mock, folders=['Bar', 'Baz'])
+    def test_filters_out_none_tracks(self, web_track_mock, web_playlist_mock):
+        del web_track_mock['type']
 
-        assert playlist.name == 'Bar/Baz/Foo'
-
-    def test_filters_out_none_tracks(self, sp_track_mock, sp_playlist_mock):
-        sp_track_mock.is_loaded = False
-
-        playlist = translator.to_playlist(sp_playlist_mock)
+        playlist = translator.to_playlist(web_playlist_mock)
 
         assert playlist.length == 0
         assert list(playlist.tracks) == []
@@ -318,45 +336,40 @@ class TestToPlaylist(object):
 class TestToPlaylistRef(object):
 
     def test_returns_none_if_unloaded(self):
-        sp_playlist = mock.Mock(spec=spotify.Playlist)
-        sp_playlist.is_loaded = False
+        web_playlist = {}
 
-        ref = translator.to_playlist_ref(sp_playlist)
-
-        assert ref is None
-
-    def test_returns_none_if_playlist_folder(self):
-        sp_playlist_folder = mock.Mock(spec=spotify.PlaylistFolder)
-
-        ref = translator.to_playlist_ref(sp_playlist_folder)
+        ref = translator.to_playlist_ref(web_playlist)
 
         assert ref is None
 
-    def test_successful_translation(self, sp_track_mock, sp_playlist_mock):
-        ref = translator.to_playlist_ref(sp_playlist_mock)
+    def test_returns_none_if_wrong_type(self, web_playlist_mock):
+        web_playlist_mock['type'] = 'track'
+
+        ref = translator.to_playlist_ref(web_playlist_mock)
+
+        assert ref is None
+
+    def test_successful_translation(self, web_playlist_mock):
+        ref = translator.to_playlist_ref(web_playlist_mock)
 
         assert ref.uri == 'spotify:user:alice:playlist:foo'
         assert ref.name == 'Foo'
 
-    def test_adds_name_for_starred_playlists(self, sp_starred_mock):
-        ref = translator.to_playlist_ref(sp_starred_mock)
+    def test_success_without_track_data(self, web_playlist_mock):
+        del web_playlist_mock['tracks']
 
-        assert ref.name == 'Starred'
+        ref = translator.to_playlist_ref(web_playlist_mock)
+
+        assert ref.uri == 'spotify:user:alice:playlist:foo'
+        assert ref.name == 'Foo'
 
     def test_includes_by_owner_in_name_if_owned_by_another_user(
-            self, sp_playlist_mock, sp_user_mock):
-        sp_user_mock.canonical_name = 'bob'
-        sp_playlist_mock.user = sp_user_mock
+            self, web_playlist_mock):
+        web_playlist_mock['owner']['id'] = 'bob'
 
-        ref = translator.to_playlist_ref(sp_playlist_mock, username='alice')
+        ref = translator.to_playlist_ref(web_playlist_mock, username='alice')
 
         assert ref.name == 'Foo (by bob)'
-
-    def test_includes_folders_in_name(self, sp_playlist_mock):
-        ref = translator.to_playlist_ref(
-            sp_playlist_mock, folders=['Bar', 'Baz'])
-
-        assert ref.name == 'Bar/Baz/Foo'
 
 
 class TestSpotifySearchQuery(object):
@@ -468,3 +481,26 @@ class TestWebToTrack(object):
         assert track.track_no == 7
         assert track.disc_no == 1
         assert track.length == 174300
+
+    def test_sets_bitrate(self, web_track_mock):
+        track = translator.web_to_track(web_track_mock, bitrate=100)
+
+        assert track.bitrate == 100
+
+    def test_filters_out_none_artists(self, web_track_mock):
+        web_track_mock['artists'].insert(0, {})
+        web_track_mock['artists'].insert(0, {'foo': 'bar'})
+
+        track = translator.web_to_track(web_track_mock)
+        artists = [models.Artist(uri='spotify:artist:abba', name='ABBA')]
+
+        assert list(track.artists) == artists
+
+    def test_ignores_missing_album(self, web_track_mock):
+        del web_track_mock['album']
+
+        track = translator.web_to_track(web_track_mock)
+
+        assert track.name == 'ABC 123'
+        assert track.length == 174300
+        assert track.album is None

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import urllib
+
 import mock
 
 import pytest
@@ -463,3 +465,320 @@ def test_cache_miss_no_etag(web_response_mock_etag, oauth_client, mock_time):
     assert 'If-None-Match' not in responses.calls[0].request.headers
     assert result['uri'] == 'spotify:track:xyz'
     assert cache['tracks/xyz'] == result
+
+
+@pytest.fixture
+def spotify_client(config):
+    return web.SpotifyOAuthClient(
+        config['spotify']['client_id'],
+        config['spotify']['client_secret'],
+        None)
+
+
+@pytest.yield_fixture(scope='class')
+def skip_refresh_token():
+    patcher = mock.patch.object(web.OAuthClient, '_should_refresh_token')
+    mock_refresh = patcher.start()
+    mock_refresh.return_value = False
+    yield mock_refresh
+    patcher.stop()
+
+
+@pytest.mark.usefixtures('skip_refresh_token')
+class TestSpotifyOAuthClient(object):
+
+    def url(self, endpoint):
+        return 'https://api.spotify.com/v1/%s' % endpoint
+
+    @pytest.mark.parametrize('field', [
+        ('next'),
+        ('items(track'),
+        ('type'),
+        ('uri'),
+        ('name'),
+        ('is_playable'),
+        ('linked_from'),
+    ])
+    def test_track_required_fields(self, field, spotify_client):
+        assert field in spotify_client.TRACK_FIELDS
+
+    @pytest.mark.parametrize('field', [
+        ('name'),
+        ('type'),
+        ('uri'),
+        ('name'),
+        ('snapshot_id'),
+        ('tracks'),
+    ])
+    def test_playlist_required_fields(self, field, spotify_client):
+        assert field in spotify_client.PLAYLIST_FIELDS
+
+    def test_configures_auth(self):
+        client = web.SpotifyOAuthClient('1234567', 'AbCdEfG', None)
+
+        assert client._auth == ('1234567', 'AbCdEfG')
+
+    def test_configures_proxy(self):
+        proxy_config = {
+            'scheme': 'https',
+            'hostname': 'my-proxy.example.com',
+            'port': 8080,
+            'username': 'alice',
+            'password': 's3cret',
+        }
+        client = web.SpotifyOAuthClient(None, None, proxy_config)
+
+        assert (client._session.proxies['https'] ==
+                'https://alice:s3cret@my-proxy.example.com:8080')
+
+    def test_configures_urls(self, spotify_client):
+        assert spotify_client._base_url == 'https://api.spotify.com/v1'
+        assert (spotify_client._refresh_url ==
+                'https://auth.mopidy.com/spotify/token')
+
+    @responses.activate
+    def test_login_alice(self, spotify_client, caplog):
+        responses.add(responses.GET, self.url('me'), json={'id': 'alice'})
+
+        assert spotify_client.login()
+        assert spotify_client.user_id == 'alice'
+        assert 'Logged into Spotify Web API as alice' in caplog.text
+
+    @responses.activate
+    def test_login_fails(self, spotify_client, caplog):
+        responses.add(responses.GET, self.url('me'), json={})
+
+        assert not spotify_client.login()
+        assert spotify_client.user_id is None
+        assert 'Failed to load Spotify user profile' in caplog.text
+
+    @responses.activate
+    def test_get_all(self, spotify_client):
+        responses.add(
+            responses.GET, self.url('page1'), json={'n': 1, 'next': 'page2'})
+        responses.add(
+            responses.GET, self.url('page2'), json={'n': 2})
+
+        results = list(spotify_client.get_all('page1'))
+
+        assert len(results) == 2
+        assert results[0].get('n') == 1
+        assert results[1].get('n') == 2
+
+    @responses.activate
+    def test_get_all_none(self, spotify_client):
+        results = list(spotify_client.get_all(None))
+
+        assert len(responses.calls) == 0
+        assert len(results) == 0
+
+    @responses.activate
+    def test_get_user_playlists_empty(self, spotify_client):
+        responses.add(responses.GET, self.url('me/playlists'), json={})
+
+        result = list(spotify_client.get_user_playlists())
+
+        assert len(responses.calls) == 1
+        assert len(result) == 0
+
+    @responses.activate
+    def test_get_user_playlists_sets_params(self, spotify_client):
+        responses.add(responses.GET, self.url('me/playlists'), json={})
+
+        list(spotify_client.get_user_playlists())
+
+        assert len(responses.calls) == 1
+        encoded_params = urllib.urlencode({'limit': 50})
+        assert (responses.calls[0].request.url ==
+                self.url('me/playlists?%s' % encoded_params))
+
+    @responses.activate
+    def test_get_user_playlists(self, spotify_client):
+        responses.add(
+            responses.GET, self.url('me/playlists?limit=50'),
+            json={
+                'next': self.url('me/playlists?offset=50'),
+                'items': ['playlist0', 'playlist1', 'playlist2'],
+            })
+        responses.add(
+            responses.GET, self.url('me/playlists?limit=50&offset=50'),
+            json={
+                'next': None,
+                'items': ['playlist3', 'playlist4', 'playlist5'],
+            })
+
+        results = list(spotify_client.get_user_playlists())
+
+        assert len(responses.calls) == 2
+        assert len(results) == 6
+        assert ['playlist%u' % i for i in range(6)] == results
+
+    @responses.activate
+    def test_get_user_playlists_uses_cache(self, spotify_client, mock_time):
+        web_resp = web.WebResponse(
+            'me/playlists?limit=50', {'items': ['playlist']}, status_code=200)
+        cache = {web_resp.url: web_resp}
+        mock_time.return_value = -1000
+
+        result = list(spotify_client.get_user_playlists(cache))
+
+        assert len(responses.calls) == 0
+        assert result[0] == 'playlist'
+
+    @responses.activate
+    @pytest.mark.parametrize('uri,success', [
+        ('spotify:user:alice:playlist:foo', True),
+        ('spotify:user:alice:playlist:fake', False),
+        ('spotify:playlist:foo', True),
+        ('spotify:track:foo', False),
+        ('https://play.spotify.com/foo', False),
+        ('total/junk', False),
+    ])
+    def test_get_playlist(
+            self, spotify_client, web_playlist_mock, uri, success):
+        responses.add(
+            responses.GET, self.url('playlists/foo'), json=web_playlist_mock)
+        responses.add(
+            responses.GET, self.url('playlists/fake'), json=None)
+
+        result = spotify_client.get_playlist(uri)
+
+        if success:
+            assert result == web_playlist_mock
+        else:
+            assert result == {}
+
+    @responses.activate
+    def test_get_playlist_sets_params_for_playlist(self, spotify_client):
+        responses.add(responses.GET, self.url('playlists/foo'), json={})
+
+        spotify_client.get_playlist('spotify:playlist:foo')
+
+        assert len(responses.calls) == 1
+        encoded_params = urllib.urlencode({
+            'fields': spotify_client.PLAYLIST_FIELDS,
+            'market': 'from_token'})
+        assert (responses.calls[0].request.url ==
+                self.url('playlists/foo?%s' % encoded_params))
+
+    @responses.activate
+    def test_get_playlist_sets_params_for_tracks(self, spotify_client):
+        responses.add(
+            responses.GET, self.url('playlists/foo'),
+            json={'tracks': {'next': 'playlists/foo/tracks1'}})
+        responses.add(
+            responses.GET, self.url('playlists/foo/tracks1'),
+            json={'next': 'playlists/foo/tracks2'})
+        responses.add(
+            responses.GET, self.url('playlists/foo/tracks2'),
+            json={})
+
+        spotify_client.get_playlist('spotify:playlist:foo')
+
+        assert len(responses.calls) == 3
+        encoded_params = urllib.urlencode({
+            'fields': spotify_client.TRACK_FIELDS,
+            'market': 'from_token'})
+        assert (responses.calls[1].request.url ==
+                self.url('playlists/foo/tracks1?%s' % encoded_params))
+        assert (responses.calls[2].request.url ==
+                self.url('playlists/foo/tracks2?%s' % encoded_params))
+
+    @responses.activate
+    def test_get_playlist_collates_tracks(self, spotify_client):
+        responses.add(
+            responses.GET, self.url('playlists/foo'),
+            json={'tracks': {'items': [1, 2], 'next': 'playlists/foo/tracks'}})
+        responses.add(
+            responses.GET, self.url('playlists/foo/tracks'),
+            json={'items': [3, 4, 5]})
+
+        result = spotify_client.get_playlist('spotify:playlist:foo')
+
+        assert len(responses.calls) == 2
+        assert result['tracks']['items'] == [1, 2, 3, 4, 5]
+
+    @responses.activate
+    def test_get_playlist_uses_cache(self, mock_time, spotify_client):
+        responses.add(
+            responses.GET, self.url('playlists/foo'),
+            json={'tracks': {'items': [1, 2], 'next': 'playlists/foo/tracks'}})
+        responses.add(
+            responses.GET, self.url('playlists/foo/tracks'),
+            json={'items': [3, 4, 5]})
+        mock_time.return_value = -1000
+
+        cache = {}
+        result1 = spotify_client.get_playlist('spotify:playlist:foo', cache)
+
+        assert len(responses.calls) == 2
+        assert result1['tracks']['items'] == [1, 2, 3, 4, 5]
+
+        assert len(cache) == 2
+        base_url = self.url('')
+        url0 = responses.calls[0].request.url[len(base_url):]
+        assert cache[url0]['tracks']['items'] == [1, 2]
+        url1 = responses.calls[1].request.url[len(base_url):]
+        assert cache[url1]['items'] == [3, 4, 5]
+
+        responses.calls.reset()
+        result2 = spotify_client.get_playlist('spotify:playlist:foo', cache)
+
+        assert len(responses.calls) == 0
+        assert result1 == result2
+
+    @pytest.mark.parametrize('uri,msg', [
+        ('spotify:artist:foo', 'Spotify playlist'),
+        ('my-bad-uri', 'Spotify'),
+    ])
+    def test_get_playlist_error_msg(self, spotify_client, caplog, uri, msg):
+        assert spotify_client.get_playlist(uri) == {}
+        assert 'Could not parse %r as a %s URI' % (uri, msg) in caplog.text
+
+
+@pytest.mark.parametrize('uri,type_,id_', [
+    ('spotify:playlist:foo', 'playlist', 'foo'),
+    ('spotify:track:bar', 'track', 'bar'),
+    ('spotify:artist:blah', 'artist', 'blah'),
+    ('spotify:album:stuff', 'album', 'stuff'),
+])
+def test_parse_uri_spotify_uri(uri, type_, id_):
+    result = web.parse_uri(uri)
+
+    assert result.uri == uri
+    assert result.type == type_
+    assert result.id == id_
+    assert result.owner is None
+
+
+@pytest.mark.parametrize('uri,id_,owner', [
+    ('spotify:user:alice:playlist:foo', 'foo', 'alice'),
+    ('spotify:playlist:foo', 'foo', None),
+    ('http://open.spotify.com/playlist/foo', 'foo', None),
+    ('https://open.spotify.com/playlist/foo', 'foo', None),
+    ('https://play.spotify.com/playlist/foo', 'foo', None),
+])
+def test_parse_uri_playlist(uri, id_, owner):
+    result = web.parse_uri(uri)
+
+    assert result.uri == uri
+    assert result.type == 'playlist'
+    assert result.id == id_
+    assert result.owner == owner
+
+
+@pytest.mark.parametrize('uri', [
+    ('spotify:user:alice:track:foo'),
+    ('local:user:alice:playlist:foo'),
+    ('spotify:track:foo:bar'),
+    ('spotify:album:'),
+    ('https://yahoo.com/playlist/foo'),
+    ('https://play.spotify.com/foo'),
+    ('total/junk'),
+])
+def test_parse_uri_raises(uri):
+    with pytest.raises(ValueError) as excinfo:
+        result = web.parse_uri(uri)
+        assert result is None
+
+    assert 'Could not parse %r as a Spotify URI' % uri in str(excinfo.value)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -499,8 +499,8 @@ class TestSpotifyOAuthClient(object):
         ('is_playable'),
         ('linked_from'),
     ])
-    def test_track_required_fields(self, field, spotify_client):
-        assert field in spotify_client.TRACK_FIELDS
+    def test_track_required_fields(self, field):
+        assert field in web.SpotifyOAuthClient.TRACK_FIELDS
 
     @pytest.mark.parametrize('field', [
         ('name'),
@@ -510,8 +510,8 @@ class TestSpotifyOAuthClient(object):
         ('snapshot_id'),
         ('tracks'),
     ])
-    def test_playlist_required_fields(self, field, spotify_client):
-        assert field in spotify_client.PLAYLIST_FIELDS
+    def test_playlist_required_fields(self, field):
+        assert field in web.SpotifyOAuthClient.PLAYLIST_FIELDS
 
     def test_configures_auth(self):
         client = web.SpotifyOAuthClient('1234567', 'AbCdEfG', None)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -254,6 +254,32 @@ def test_web_response_status_ok(status_code, expected):
     assert response.status_ok == expected
 
 
+@pytest.mark.parametrize('status_code,expected', [
+    (200, False),
+    (301, False),
+    (304, True),
+    (400, False),
+])
+def test_web_response_status_unchanged(status_code, expected):
+    response = web.WebResponse('https://foo.com', {}, status_code=status_code)
+    assert not response._from_cache
+    assert response.status_unchanged == expected
+
+
+def test_web_response_status_unchanged_from_cache():
+    response = web.WebResponse('https://foo.com', {})
+
+    assert not response.status_unchanged
+
+    response.still_valid(ignore_expiry=True)
+
+    assert response.status_unchanged
+
+    response.updated(response)
+
+    assert not response.status_unchanged
+
+
 @pytest.mark.parametrize('etag,expected', [
     ('"1234"', {'If-None-Match': '"1234"'}),
     ('fish', {'If-None-Match': 'fish'}),
@@ -327,7 +353,7 @@ def test_web_response(web_track_mock, mock_time, oauth_client):
     assert result._status_code == 301
     assert result._expires == 1001
     assert result._etag == '"12345"'
-    assert not result.expired
+    assert result.still_valid()
     assert result.status_ok
     assert result['uri'] == 'spotify:track:abc'
 
@@ -348,13 +374,13 @@ def test_cache_miss(web_track_mock, mock_time, oauth_client):
 
 
 @responses.activate
-def test_cache_hit_not_expired(
+def test_cache_response_still_valid(
         web_response_mock, mock_time, oauth_client, caplog):
     cache = {'https://api.spotify.com/v1/tracks/abc': web_response_mock}
     oauth_client._expires = 2000
     mock_time.return_value = 999
 
-    assert not web_response_mock.expired
+    assert web_response_mock.still_valid()
     assert 'Cached data fresh for' in caplog.text
 
     result = oauth_client.get('https://api.spotify.com/v1/tracks/abc', cache)
@@ -363,7 +389,7 @@ def test_cache_hit_not_expired(
 
 
 @responses.activate
-def test_cache_hit_expired(
+def test_cache_response_expired(
         web_response_mock, oauth_client, mock_time, caplog):
     cache = {'https://api.spotify.com/v1/tracks/abc': web_response_mock}
     responses.add(
@@ -372,12 +398,31 @@ def test_cache_hit_expired(
     oauth_client._expires = 2000
     mock_time.return_value = 1001
 
-    assert web_response_mock.expired
+    assert not web_response_mock.still_valid()
     assert 'Cached data expired for' in caplog.text
 
     result = oauth_client.get('https://api.spotify.com/v1/tracks/abc', cache)
     assert len(responses.calls) == 1
     assert result['uri'] == 'new'
+
+
+@responses.activate
+def test_cache_response_ignore_expiry(
+        web_response_mock, oauth_client, mock_time, caplog):
+    cache = {'https://api.spotify.com/v1/tracks/abc': web_response_mock}
+    responses.add(
+        responses.GET, 'https://api.spotify.com/v1/tracks/abc',
+        json={'uri': 'new'})
+    oauth_client._expires = 2000
+    mock_time.return_value = 1001
+
+    assert web_response_mock.still_valid(True)
+    assert 'Cached data forced for' in caplog.text
+
+    result = oauth_client.get('https://api.spotify.com/v1/tracks/abc', cache,
+                              ignore_expiry=True)
+    assert len(responses.calls) == 0
+    assert result['uri'] == 'spotify:track:abc'
 
 
 @responses.activate
@@ -467,6 +512,67 @@ def test_cache_miss_no_etag(web_response_mock_etag, oauth_client, mock_time):
     assert cache['tracks/xyz'] == result
 
 
+def test_increase_expiry(web_response_mock):
+    web_response_mock.increase_expiry(30)
+
+    assert web_response_mock._expires == 1030
+
+
+def test_increase_expiry_skipped_for_bad_status(web_response_mock):
+    web_response_mock._status_code = 404
+
+    web_response_mock.increase_expiry(30)
+
+    assert web_response_mock._expires == 1000
+
+
+def test_increase_expiry_skipped_for_cached_response(web_response_mock):
+    web_response_mock._from_cache = True
+
+    web_response_mock.increase_expiry(30)
+
+    assert web_response_mock._expires == 1000
+
+
+@responses.activate
+def test_fresh_response_changed(oauth_client, mock_time):
+    cache = {}
+    responses.add(responses.GET, 'https://api.spotify.com/v1/foo', json={})
+    oauth_client._expires = 2000
+    mock_time.return_value = 1
+
+    result = oauth_client.get('foo', cache)
+
+    assert len(responses.calls) == 1
+    assert not result.status_unchanged
+
+
+@responses.activate
+def test_cached_response_unchanged(web_response_mock, oauth_client, mock_time):
+    cache = {'foo': web_response_mock}
+    responses.add(responses.GET, 'https://api.spotify.com/v1/foo', json={})
+    oauth_client._expires = 2000
+    mock_time.return_value = 1
+
+    result = oauth_client.get('foo', cache)
+
+    assert len(responses.calls) == 0
+    assert result.status_unchanged
+
+
+@responses.activate
+def test_updated_responses_changed(web_response_mock, oauth_client, mock_time):
+    cache = {'foo': web_response_mock}
+    responses.add(responses.GET, 'https://api.spotify.com/v1/foo', json={})
+    oauth_client._expires = 2000
+    mock_time.return_value = 1001
+
+    result = oauth_client.get('foo', cache)
+
+    assert len(responses.calls) == 1
+    assert not result.status_unchanged
+
+
 @pytest.fixture
 def spotify_client(config):
     return web.SpotifyOAuthClient(
@@ -553,6 +659,25 @@ class TestSpotifyOAuthClient(object):
         assert 'Failed to load Spotify user profile' in caplog.text
 
     @responses.activate
+    def test_get_one_cached(self, spotify_client):
+        responses.add(responses.GET, self.url('foo'))
+
+        spotify_client.get_one('foo')
+        spotify_client.get_one('foo')
+
+        assert len(responses.calls) == 1
+        assert 'foo' in spotify_client._cache
+
+    @responses.activate
+    def test_get_one_increased_expiry(self, mock_time, spotify_client):
+        responses.add(responses.GET, self.url('foo'))
+        mock_time.return_value = 1000
+
+        result = spotify_client.get_one('foo')
+
+        assert 1000 + spotify_client.DEFAULT_EXTRA_EXPIRY == result._expires
+
+    @responses.activate
     def test_get_all(self, spotify_client):
         responses.add(
             responses.GET, self.url('page1'), json={'n': 1, 'next': 'page2'})
@@ -612,18 +737,6 @@ class TestSpotifyOAuthClient(object):
         assert len(responses.calls) == 2
         assert len(results) == 6
         assert ['playlist%u' % i for i in range(6)] == results
-
-    @responses.activate
-    def test_get_user_playlists_uses_cache(self, spotify_client, mock_time):
-        web_resp = web.WebResponse(
-            'me/playlists?limit=50', {'items': ['playlist']}, status_code=200)
-        spotify_client._cache = {web_resp.url: web_resp}
-        mock_time.return_value = -1000
-
-        result = list(spotify_client.get_user_playlists())
-
-        assert len(responses.calls) == 0
-        assert result[0] == 'playlist'
 
     @responses.activate
     @pytest.mark.parametrize('uri,success', [
@@ -699,10 +812,12 @@ class TestSpotifyOAuthClient(object):
         assert result['tracks']['items'] == [1, 2, 3, 4, 5]
 
     @responses.activate
-    def test_get_playlist_uses_cache(self, mock_time, spotify_client):
+    def test_get_playlist_uses_cached_tracks_when_unchanged(
+            self, mock_time, spotify_client):
         responses.add(
             responses.GET, self.url('playlists/foo'),
-            json={'tracks': {'items': [1, 2], 'next': 'playlists/foo/tracks'}})
+            json={'tracks': {'items': [1, 2], 'next': 'playlists/foo/tracks'}},
+            status=304)
         responses.add(
             responses.GET, self.url('playlists/foo/tracks'),
             json={'items': [3, 4, 5]})
@@ -712,19 +827,15 @@ class TestSpotifyOAuthClient(object):
 
         assert len(responses.calls) == 2
         assert result1['tracks']['items'] == [1, 2, 3, 4, 5]
-
         assert len(spotify_client._cache) == 2
-        base_url = self.url('')
-        url0 = responses.calls[0].request.url[len(base_url):]
-        assert spotify_client._cache[url0]['tracks']['items'] == [1, 2]
-        url1 = responses.calls[1].request.url[len(base_url):]
-        assert spotify_client._cache[url1]['items'] == [3, 4, 5]
 
         responses.calls.reset()
+        mock_time.return_value = 1000
+
         result2 = spotify_client.get_playlist('spotify:playlist:foo')
 
-        assert len(responses.calls) == 0
-        assert result1 == result2
+        assert len(responses.calls) == 1
+        assert result1['tracks']['items'] == result2['tracks']['items']
 
     @pytest.mark.parametrize('uri,msg', [
         ('spotify:artist:foo', 'Spotify playlist'),
@@ -734,12 +845,21 @@ class TestSpotifyOAuthClient(object):
         assert spotify_client.get_playlist(uri) == {}
         assert 'Could not parse %r as a %s URI' % (uri, msg) in caplog.text
 
-    def test_clear_data(self, spotify_client):
+    def test_clear_cache(self, spotify_client):
         spotify_client._cache = {'foo': 'bar'}
 
-        assert len(spotify_client._cache) > 0
-        spotify_client.clear_data()
-        assert len(spotify_client._cache) == 0
+        spotify_client.clear_cache()
+
+        assert {} == spotify_client._cache
+
+    @pytest.mark.parametrize('user_id,expected', [
+        ('alice', True),
+        (None, False),
+    ])
+    def test_logged_in(self, spotify_client, user_id, expected):
+        spotify_client.user_id = user_id
+
+        assert spotify_client.logged_in is expected
 
 
 @pytest.mark.parametrize('uri,type_,id_', [

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -617,10 +617,10 @@ class TestSpotifyOAuthClient(object):
     def test_get_user_playlists_uses_cache(self, spotify_client, mock_time):
         web_resp = web.WebResponse(
             'me/playlists?limit=50', {'items': ['playlist']}, status_code=200)
-        cache = {web_resp.url: web_resp}
+        spotify_client._cache = {web_resp.url: web_resp}
         mock_time.return_value = -1000
 
-        result = list(spotify_client.get_user_playlists(cache))
+        result = list(spotify_client.get_user_playlists())
 
         assert len(responses.calls) == 0
         assert result[0] == 'playlist'
@@ -708,21 +708,20 @@ class TestSpotifyOAuthClient(object):
             json={'items': [3, 4, 5]})
         mock_time.return_value = -1000
 
-        cache = {}
-        result1 = spotify_client.get_playlist('spotify:playlist:foo', cache)
+        result1 = spotify_client.get_playlist('spotify:playlist:foo')
 
         assert len(responses.calls) == 2
         assert result1['tracks']['items'] == [1, 2, 3, 4, 5]
 
-        assert len(cache) == 2
+        assert len(spotify_client._cache) == 2
         base_url = self.url('')
         url0 = responses.calls[0].request.url[len(base_url):]
-        assert cache[url0]['tracks']['items'] == [1, 2]
+        assert spotify_client._cache[url0]['tracks']['items'] == [1, 2]
         url1 = responses.calls[1].request.url[len(base_url):]
-        assert cache[url1]['items'] == [3, 4, 5]
+        assert spotify_client._cache[url1]['items'] == [3, 4, 5]
 
         responses.calls.reset()
-        result2 = spotify_client.get_playlist('spotify:playlist:foo', cache)
+        result2 = spotify_client.get_playlist('spotify:playlist:foo')
 
         assert len(responses.calls) == 0
         assert result1 == result2
@@ -734,6 +733,13 @@ class TestSpotifyOAuthClient(object):
     def test_get_playlist_error_msg(self, spotify_client, caplog, uri, msg):
         assert spotify_client.get_playlist(uri) == {}
         assert 'Could not parse %r as a %s URI' % (uri, msg) in caplog.text
+
+    def test_clear_data(self, spotify_client):
+        spotify_client._cache = {'foo': 'bar'}
+
+        assert len(spotify_client._cache) > 0
+        spotify_client.clear_data()
+        assert len(spotify_client._cache) == 0
 
 
 @pytest.mark.parametrize('uri,type_,id_', [


### PR DESCRIPTION
This branch is the successor to #188 and aimed at fixing #140 and #182.

- [x] Cache playlist API response data
- [x] Support Spotify's new playlist URI scheme
- [x] ~~Save cached data to file on exit and restore on login~~ - not in this PR
- [ ] Translator should use @memoized decorator?
- [x] Track translators need to consider market availability
- [x] Tests
- [x] Handle playlists refresh

I'm not happy with returning the raw (mutable) cache data dict to `SpotifyOAuthClient` and this led to the hacky workaround at https://github.com/kingosticks/mopidy-spotify/blob/fix/web-api-playlists-v2/mopidy_spotify/web.py#L440-L443. Returning something immutable like a `namedtuple` might be better. 