### PR TITLE
Web API playlists v3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,16 @@ Changelog
 *********
 
 
+v4.0.0a2 (UNRELEASED)
+=====================
+
+Alpha release.
+
+- Use the Spotify Web API for playlists. (#182, #122, PR: #235)
+ 
+
 v4.0.0a1 (2019-11-18)
-======================
+=====================
 
 Alpha release.
 

--- a/README.rst
+++ b/README.rst
@@ -34,11 +34,6 @@ way for us to provide some Spotify features.
 Limitations and/or bugs in ``libspotify`` currently result in missing/broken
 Mopidy-Spotify support for the following:
 
-- Playlists (`#182 <https://github.com/mopidy/mopidy-spotify/issues/182>`_,
-  `#122 <https://github.com/mopidy/mopidy-spotify/issues/122>`_) - available
-  via web API using
-  `#228 <https://github.com/mopidy/mopidy-spotify/pull/228>`_
-
 - My Music (`#16 <https://github.com/mopidy/mopidy-spotify/issues/16>`_,
   `#108 <https://github.com/mopidy/mopidy-spotify/issues/108>`_) - available via
   web API
@@ -61,7 +56,9 @@ Working support for the following features is currently available:
 
 - Search
 
-- Lookup by URI (except playlists)
+- Playlists
+
+- Lookup by URI
 
 
 Dependencies

--- a/mopidy_spotify/__init__.py
+++ b/mopidy_spotify/__init__.py
@@ -1,7 +1,6 @@
 import pathlib
 
 import pkg_resources
-
 from mopidy import config, ext
 
 __version__ = pkg_resources.get_distribution("Mopidy-Spotify").version

--- a/mopidy_spotify/backend.py
+++ b/mopidy_spotify/backend.py
@@ -57,13 +57,13 @@ class SpotifyBackend(pykka.ThreadingActor, backend.Backend):
             self._config["spotify"]["password"],
         )
 
-        self._web_client = web.OAuthClient(
-            base_url="https://api.spotify.com/v1",
-            refresh_url="https://auth.mopidy.com/spotify/token",
-            client_id=self._config["spotify"]["client_id"],
-            client_secret=self._config["spotify"]["client_secret"],
-            proxy_config=self._config["proxy"],
+        self._web_client = web.SpotifyOAuthClient(
+            self._config["spotify"]["client_id"],
+            self._config["spotify"]["client_secret"],
+            self._config["proxy"],
         )
+
+        self._web_client.login()
 
     def on_stop(self):
         logger.debug("Logging out of Spotify")

--- a/mopidy_spotify/backend.py
+++ b/mopidy_spotify/backend.py
@@ -64,6 +64,9 @@ class SpotifyBackend(pykka.ThreadingActor, backend.Backend):
         )
         self._web_client.login()
 
+        if self.playlists is not None:
+            self.playlists.refresh()
+
     def on_stop(self):
         logger.debug("Logging out of Spotify")
         self._session.logout()

--- a/mopidy_spotify/backend.py
+++ b/mopidy_spotify/backend.py
@@ -58,9 +58,9 @@ class SpotifyBackend(pykka.ThreadingActor, backend.Backend):
         )
 
         self._web_client = web.SpotifyOAuthClient(
-            self._config["spotify"]["client_id"],
-            self._config["spotify"]["client_secret"],
-            self._config["proxy"],
+            client_id=self._config["spotify"]["client_id"],
+            client_secret=self._config["spotify"]["client_secret"],
+            proxy_config=self._config["proxy"],
         )
         self._web_client.login()
 

--- a/mopidy_spotify/backend.py
+++ b/mopidy_spotify/backend.py
@@ -3,9 +3,9 @@ import pathlib
 import threading
 
 import pykka
-import spotify
-
 from mopidy import backend, httpclient
+
+import spotify
 from mopidy_spotify import Extension, library, playback, playlists, web
 
 logger = logging.getLogger(__name__)
@@ -62,7 +62,6 @@ class SpotifyBackend(pykka.ThreadingActor, backend.Backend):
             self._config["spotify"]["client_secret"],
             self._config["proxy"],
         )
-
         self._web_client.login()
 
     def on_stop(self):
@@ -125,23 +124,6 @@ class SpotifyBackend(pykka.ThreadingActor, backend.Backend):
         if self._config["spotify"]["private_session"]:
             logger.info("Spotify private session activated")
             self._session.social.private_session = True
-
-        self._session.playlist_container.on(
-            spotify.PlaylistContainerEvent.CONTAINER_LOADED,
-            playlists.on_container_loaded,
-        )
-        self._session.playlist_container.on(
-            spotify.PlaylistContainerEvent.PLAYLIST_ADDED,
-            playlists.on_playlist_added,
-        )
-        self._session.playlist_container.on(
-            spotify.PlaylistContainerEvent.PLAYLIST_REMOVED,
-            playlists.on_playlist_removed,
-        )
-        self._session.playlist_container.on(
-            spotify.PlaylistContainerEvent.PLAYLIST_MOVED,
-            playlists.on_playlist_moved,
-        )
 
     def on_play_token_lost(self):
         if self._session.player.state == spotify.PlayerState.PLAYING:

--- a/mopidy_spotify/browse.py
+++ b/mopidy_spotify/browse.py
@@ -1,8 +1,8 @@
 import logging
 
-import spotify
-
 from mopidy import models
+
+import spotify
 from mopidy_spotify import countries, translator
 
 logger = logging.getLogger(__name__)

--- a/mopidy_spotify/distinct.py
+++ b/mopidy_spotify/distinct.py
@@ -1,7 +1,6 @@
 import logging
 
 import spotify
-
 from mopidy_spotify import search
 
 logger = logging.getLogger(__name__)

--- a/mopidy_spotify/library.py
+++ b/mopidy_spotify/library.py
@@ -1,6 +1,7 @@
 import logging
 
 from mopidy import backend
+
 from mopidy_spotify import browse, distinct, images, lookup, search
 
 logger = logging.getLogger(__name__)
@@ -29,7 +30,9 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
         return images.get_images(self._backend._web_client, uris)
 
     def lookup(self, uri):
-        return lookup.lookup(self._config, self._backend._session, uri)
+        return lookup.lookup(
+            self._config, self._backend._session, self._backend._web_client, uri
+        )
 
     def search(self, query=None, uris=None, exact=False):
         return search.search(

--- a/mopidy_spotify/lookup.py
+++ b/mopidy_spotify/lookup.py
@@ -12,15 +12,15 @@ _VARIOUS_ARTISTS_URIS = [
 
 def lookup(config, session, web_client, uri):
     try:
-        web_link = web.parse_uri(uri)
-        if web_link.type != "playlist":
+        web_link = web.WebLink.from_uri(uri)
+        if web_link.type != web.LinkType.PLAYLIST:
             sp_link = session.get_link(uri)
     except ValueError as exc:
         logger.info(f"Failed to lookup {uri!r}: {exc}")
         return []
 
     try:
-        if web_link.type == "playlist":
+        if web_link.type == web.LinkType.PLAYLIST:
             return _lookup_playlist(config, session, web_client, uri)
         elif sp_link.type is spotify.LinkType.TRACK:
             return list(_lookup_track(config, sp_link))

--- a/mopidy_spotify/lookup.py
+++ b/mopidy_spotify/lookup.py
@@ -21,7 +21,7 @@ def lookup(config, session, web_client, uri):
 
     try:
         if web_link.type == "playlist":
-            return _lookup_playlist(config, web_client, uri)
+            return _lookup_playlist(config, session, web_client, uri)
         elif sp_link.type is spotify.LinkType.TRACK:
             return list(_lookup_track(config, sp_link))
         elif sp_link.type is spotify.LinkType.ALBUM:
@@ -85,8 +85,10 @@ def _lookup_artist(config, sp_link):
                 yield track
 
 
-def _lookup_playlist(config, web_client, uri):
-    playlist = playlists.playlist_lookup(web_client, uri, config["bitrate"])
+def _lookup_playlist(config, session, web_client, uri):
+    playlist = playlists.playlist_lookup(
+        session, web_client, uri, config["bitrate"]
+    )
     if playlist is None:
         raise spotify.Error("Playlist Web API lookup failed")
     return playlist.tracks

--- a/mopidy_spotify/lookup.py
+++ b/mopidy_spotify/lookup.py
@@ -1,8 +1,7 @@
 import logging
 
 import spotify
-
-from mopidy_spotify import translator, utils
+from mopidy_spotify import playlists, translator, utils, web
 
 logger = logging.getLogger(__name__)
 
@@ -11,25 +10,25 @@ _VARIOUS_ARTISTS_URIS = [
 ]
 
 
-def lookup(config, session, uri):
+def lookup(config, session, web_client, uri):
     try:
-        sp_link = session.get_link(uri)
+        web_link = web.parse_uri(uri)
+        if web_link.type != "playlist":
+            sp_link = session.get_link(uri)
     except ValueError as exc:
         logger.info(f'Failed to lookup "{uri}": {exc}')
         return []
 
     try:
-        if sp_link.type is spotify.LinkType.TRACK:
+        if web_link.type == "playlist":
+            return _lookup_playlist(config, web_client, uri)
+        elif sp_link.type is spotify.LinkType.TRACK:
             return list(_lookup_track(config, sp_link))
         elif sp_link.type is spotify.LinkType.ALBUM:
             return list(_lookup_album(config, sp_link))
         elif sp_link.type is spotify.LinkType.ARTIST:
             with utils.time_logger("Artist lookup"):
                 return list(_lookup_artist(config, sp_link))
-        elif sp_link.type is spotify.LinkType.PLAYLIST:
-            return list(_lookup_playlist(config, sp_link))
-        elif sp_link.type is spotify.LinkType.STARRED:
-            return list(reversed(list(_lookup_playlist(config, sp_link))))
         else:
             logger.info(
                 f'Failed to lookup "{uri}": Cannot handle {repr(sp_link.type)}'
@@ -86,11 +85,8 @@ def _lookup_artist(config, sp_link):
                 yield track
 
 
-def _lookup_playlist(config, sp_link):
-    sp_playlist = sp_link.as_playlist()
-    sp_playlist.load(config["timeout"])
-    for sp_track in sp_playlist.tracks:
-        sp_track.load(config["timeout"])
-        track = translator.to_track(sp_track, bitrate=config["bitrate"])
-        if track is not None:
-            yield track
+def _lookup_playlist(config, web_client, uri):
+    playlist = playlists.playlist_lookup(web_client, uri, config["bitrate"])
+    if playlist is None:
+        raise spotify.Error("Playlist Web API lookup failed")
+    return playlist.tracks

--- a/mopidy_spotify/lookup.py
+++ b/mopidy_spotify/lookup.py
@@ -16,7 +16,7 @@ def lookup(config, session, web_client, uri):
         if web_link.type != "playlist":
             sp_link = session.get_link(uri)
     except ValueError as exc:
-        logger.info(f'Failed to lookup "{uri}": {exc}')
+        logger.info(f"Failed to lookup {uri!r}: {exc}")
         return []
 
     try:
@@ -31,11 +31,11 @@ def lookup(config, session, web_client, uri):
                 return list(_lookup_artist(config, sp_link))
         else:
             logger.info(
-                f'Failed to lookup "{uri}": Cannot handle {repr(sp_link.type)}'
+                f"Failed to lookup {uri!r}: Cannot handle {sp_link.type!r}"
             )
             return []
     except spotify.Error as exc:
-        logger.info(f'Failed to lookup "{uri}": {exc}')
+        logger.info(f"Failed to lookup {uri!r}: {exc}")
         return []
 
 

--- a/mopidy_spotify/playback.py
+++ b/mopidy_spotify/playback.py
@@ -2,9 +2,9 @@ import functools
 import logging
 import threading
 
-import spotify
-
 from mopidy import audio, backend
+
+import spotify
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -3,7 +3,6 @@ import logging
 from mopidy import backend
 
 import spotify
-
 from mopidy_spotify import translator, utils
 
 _sp_links = {}

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -113,13 +113,3 @@ def playlist_lookup(session, web_client, uri, bitrate, as_items=False):
                 logger.info(f"Failed to get link {track.uri!r}: {exc}")
 
     return playlist
-
-
-def on_playlists_loaded():
-    # Called from the pyspotify event loop, and not in an actor context.
-    logger.debug("Spotify playlists loaded")
-
-    # This event listener is also called after playlists are added, removed and
-    # moved, so since Mopidy currently only supports the "playlists_loaded"
-    # event this is the only place we need to trigger a Mopidy backend event.
-    backend.BackendListener.send("playlists_loaded")

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -13,9 +13,13 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
     def __init__(self, backend):
         self._backend = backend
         self._timeout = self._backend._config["spotify"]["timeout"]
+        self._loaded = False
 
     def as_list(self):
-        with utils.time_logger("playlists.as_list()"):
+        with utils.time_logger("playlists.as_list()", logging.INFO):
+            if not self._loaded:
+                return []
+
             return list(self._get_flattened_playlist_refs())
 
     def _get_flattened_playlist_refs(self):
@@ -34,11 +38,14 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
                 yield playlist_ref
 
     def get_items(self, uri):
-        with utils.time_logger(f"playlist.get_items({uri})"):
+        with utils.time_logger(f"playlist.get_items({uri})", logging.INFO):
+            if not self._loaded:
+                return []
+
             return self._get_playlist(uri, as_items=True)
 
     def lookup(self, uri):
-        with utils.time_logger(f"playlists.lookup({uri})"):
+        with utils.time_logger(f"playlists.lookup({uri})", logging.DEBUG):
             return self._get_playlist(uri)
 
     def _get_playlist(self, uri, as_items=False):
@@ -47,7 +54,15 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
         )
 
     def refresh(self):
-        pass  # TODO: Clear/invalidate all caches on refresh.
+        with utils.time_logger("Refresh Playlists", logging.INFO):
+            _cache.clear()
+            count = 0
+            for playlist_ref in self._get_flattened_playlist_refs():
+                self._get_playlist(playlist_ref.uri)
+                count = count + 1
+            logger.info(f"Refreshed {count} playlists")
+
+        self._loaded = True
 
     def create(self, name):
         pass  # TODO
@@ -63,7 +78,7 @@ def playlist_lookup(web_client, uri, bitrate, as_items=False):
     if web_client is None:
         return
 
-    logger.info(f'Fetching Spotify playlist "{uri}"')
+    logger.debug(f'Fetching Spotify playlist "{uri}"')
     web_playlist = web_client.get_playlist(uri, _cache)
 
     if web_playlist == {}:

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -2,9 +2,12 @@ import logging
 
 from mopidy import backend
 
+import spotify
+
 from mopidy_spotify import translator, utils
 
 _cache = {}
+_sp_links = {}
 
 logger = logging.getLogger(__name__)
 
@@ -50,12 +53,18 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
 
     def _get_playlist(self, uri, as_items=False):
         return playlist_lookup(
-            self._backend._web_client, uri, self._backend._bitrate, as_items
+            self._backend._session,
+            self._backend._web_client,
+            uri,
+            self._backend._bitrate,
+            as_items,
         )
 
     def refresh(self):
         with utils.time_logger("Refresh Playlists", logging.INFO):
             _cache.clear()
+            _sp_links.clear()
+            # Want libspotify to get track links so they load in the background
             count = 0
             for playlist_ref in self._get_flattened_playlist_refs():
                 self._get_playlist(playlist_ref.uri)
@@ -74,7 +83,7 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
         pass  # TODO
 
 
-def playlist_lookup(web_client, uri, bitrate, as_items=False):
+def playlist_lookup(session, web_client, uri, bitrate, as_items=False):
     if web_client is None:
         return
 
@@ -85,12 +94,31 @@ def playlist_lookup(web_client, uri, bitrate, as_items=False):
         logger.error(f"Failed to lookup Spotify playlist URI {uri}")
         return
 
-    return translator.to_playlist(
+    playlist = translator.to_playlist(
         web_playlist,
         username=web_client.user_id,
         bitrate=bitrate,
         as_items=as_items,
     )
+    if playlist is None:
+        return
+    # Store the libspotify Link for each track so they will be loaded in the
+    # background ready for using later.
+    if session.connection.state is spotify.ConnectionState.LOGGED_IN:
+        if as_items:
+            tracks = playlist
+        else:
+            tracks = playlist.tracks
+
+        for track in tracks:
+            if track.uri in _sp_links:
+                continue
+            try:
+                _sp_links[track.uri] = session.get_link(track.uri)
+            except ValueError as exc:
+                logger.info(f'Failed to get link "{track.uri}": {exc}')
+
+    return playlist
 
 
 def on_playlists_loaded():

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -36,11 +36,11 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
                 yield playlist_ref
 
     def get_items(self, uri):
-        with utils.time_logger(f"playlist.get_items({uri})", logging.INFO):
+        with utils.time_logger(f"playlist.get_items({uri!r})", logging.INFO):
             return self._get_playlist(uri, as_items=True)
 
     def lookup(self, uri):
-        with utils.time_logger(f"playlists.lookup({uri})", logging.DEBUG):
+        with utils.time_logger(f"playlists.lookup({uri!r})", logging.DEBUG):
             return self._get_playlist(uri)
 
     def _get_playlist(self, uri, as_items=False):
@@ -56,14 +56,14 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
         if not self._backend._web_client.logged_in:
             return
 
-        with utils.time_logger("Refresh Playlists", logging.INFO):
+        with utils.time_logger("playlists.refresh()", logging.INFO):
             _sp_links.clear()
             self._backend._web_client.clear_cache()
             count = 0
             for playlist_ref in self._get_flattened_playlist_refs():
                 self._get_playlist(playlist_ref.uri)
                 count = count + 1
-            logger.info(f"Refreshed {count} playlists")
+            logger.info(f"Refreshed {count} Spotify playlists")
 
         self._loaded = True
 
@@ -81,11 +81,11 @@ def playlist_lookup(session, web_client, uri, bitrate, as_items=False):
     if web_client is None or not web_client.logged_in:
         return
 
-    logger.debug(f'Fetching Spotify playlist "{uri}"')
+    logger.debug(f'Fetching Spotify playlist "{uri!r}"')
     web_playlist = web_client.get_playlist(uri)
 
     if web_playlist == {}:
-        logger.error(f"Failed to lookup Spotify playlist URI {uri}")
+        logger.error(f"Failed to lookup Spotify playlist URI {uri!r}")
         return
 
     playlist = translator.to_playlist(
@@ -110,7 +110,7 @@ def playlist_lookup(session, web_client, uri, bitrate, as_items=False):
             try:
                 _sp_links[track.uri] = session.get_link(track.uri)
             except ValueError as exc:
-                logger.info(f'Failed to get link "{track.uri}": {exc}')
+                logger.info(f"Failed to get link {track.uri!r}: {exc}")
 
     return playlist
 

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -17,7 +17,7 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
         self._loaded = False
 
     def as_list(self):
-        with utils.time_logger("playlists.as_list()", logging.INFO):
+        with utils.time_logger("playlists.as_list()", logging.DEBUG):
             if not self._loaded:
                 return []
 
@@ -36,7 +36,7 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
                 yield playlist_ref
 
     def get_items(self, uri):
-        with utils.time_logger(f"playlist.get_items({uri!r})", logging.INFO):
+        with utils.time_logger(f"playlist.get_items({uri!r})", logging.DEBUG):
             return self._get_playlist(uri, as_items=True)
 
     def lookup(self, uri):
@@ -56,7 +56,7 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
         if not self._backend._web_client.logged_in:
             return
 
-        with utils.time_logger("playlists.refresh()", logging.INFO):
+        with utils.time_logger("playlists.refresh()", logging.DEBUG):
             _sp_links.clear()
             self._backend._web_client.clear_cache()
             count = 0

--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -62,7 +62,7 @@ def search(
         params={
             "q": sp_query,
             "limit": search_count,
-            "market": session.user_country,
+            "market": web_client.user_country,
             "type": ",".join(types),
         },
     )

--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -1,9 +1,9 @@
 import logging
 import urllib.parse
 
-import spotify
-
 from mopidy import models
+
+import spotify
 from mopidy_spotify import lookup, translator
 
 _SEARCH_TYPES = ["album", "artist", "track"]
@@ -28,7 +28,7 @@ def search(
         return models.SearchResult(uri="spotify:search")
 
     if "uri" in query:
-        return _search_by_uri(config, session, query)
+        return _search_by_uri(config, session, web_client, query)
 
     sp_query = translator.sp_search_query(query)
     if not sp_query:
@@ -62,7 +62,7 @@ def search(
         params={
             "q": sp_query,
             "limit": search_count,
-            "market": web_client.user_country,
+            "market": "from_token",
             "type": ",".join(types),
         },
     )
@@ -105,10 +105,10 @@ def search(
     )
 
 
-def _search_by_uri(config, session, query):
+def _search_by_uri(config, session, web_client, query):
     tracks = []
     for uri in query["uri"]:
-        tracks += lookup.lookup(config, session, uri)
+        tracks += lookup.lookup(config, session, web_client, uri)
 
     uri = "spotify:search"
     if len(query["uri"]) == 1:

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -161,7 +161,7 @@ def web_to_track_ref(web_track):
     uri = web_track.get("linked_from", {}).get("uri") or web_track["uri"]
 
     if not web_track.get("is_playable", False):
-        logger.warning(f"{uri} is not playable")
+        logger.debug(f"{uri} is not playable")
         return
 
     return models.Ref.track(uri=uri, name=web_track.get("name"))

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -1,9 +1,9 @@
 import collections
 import logging
 
-import spotify
-
 from mopidy import models
+
+import spotify
 
 logger = logging.getLogger(__name__)
 
@@ -148,54 +148,62 @@ def to_track_refs(sp_tracks, timeout=None):
             yield ref
 
 
-def to_playlist(
-    sp_playlist,
-    folders=None,
-    username=None,
-    bitrate=None,
-    as_ref=False,
-    as_items=False,
-):
-    if not isinstance(sp_playlist, spotify.Playlist):
+def web_to_track_ref(web_track):
+    if web_track.get("type") != "track":
         return
 
-    if not sp_playlist.is_loaded:
+    # TODO: Check availability
+
+    return models.Ref.track(
+        uri=web_track.get("uri"), name=web_track.get("name")
+    )
+
+
+def web_to_track_refs(web_tracks):
+    for web_track in web_tracks:
+        ref = web_to_track_ref(web_track.get("track", {}))
+        if ref is not None:
+            yield ref
+
+
+def to_playlist(
+    web_playlist, username=None, bitrate=None, as_ref=False, as_items=False,
+):
+    if web_playlist.get("type") != "playlist":
+        logger.error("No playlist data present")
+        return
+
+    web_tracks = web_playlist.get("tracks", {}).get("items", [])
+    if (as_items or not as_ref) and not isinstance(web_tracks, list):
+        logger.error("No playlist track data present")
         return
 
     if as_items:
-        return list(to_track_refs(sp_playlist.tracks))
+        return list(web_to_track_refs(web_tracks))
 
-    name = sp_playlist.name
+    name = web_playlist.get("name")
 
     if not as_ref:
         tracks = [
-            to_track(sp_track, bitrate=bitrate)
-            for sp_track in sp_playlist.tracks
+            web_to_track(web_track.get("track", {}), bitrate=bitrate)
+            for web_track in web_tracks
         ]
         tracks = [t for t in tracks if t]
-        if name is None:
-            # Use same starred order as the Spotify client
-            tracks = list(reversed(tracks))
 
-    if name is None:
-        name = "Starred"
-    if folders is not None:
-        name = "/".join(folders + [name])
-    if username is not None and sp_playlist.owner.canonical_name != username:
-        name = f"{name} (by {sp_playlist.owner.canonical_name})"
+    owner = web_playlist.get("owner", {}).get("id", username)
+    if username is not None and owner != username:
+        name = f"{name} (by {owner})"
 
     if as_ref:
-        return models.Ref.playlist(uri=sp_playlist.link.uri, name=name)
+        return models.Ref.playlist(uri=web_playlist.get("uri"), name=name)
     else:
         return models.Playlist(
-            uri=sp_playlist.link.uri, name=name, tracks=tracks
+            uri=web_playlist.get("uri"), name=name, tracks=tracks
         )
 
 
-def to_playlist_ref(sp_playlist, folders=None, username=None):
-    return to_playlist(
-        sp_playlist, folders=folders, username=username, as_ref=True
-    )
+def to_playlist_ref(web_playlist, username=None):
+    return to_playlist(web_playlist, username=username, as_ref=True)
 
 
 # Maps from Mopidy search query field to Spotify search query field.
@@ -241,27 +249,46 @@ def _transform_year(date):
 
 
 def web_to_artist(web_artist):
-    return models.Artist(uri=web_artist["uri"], name=web_artist["name"])
+    if "uri" not in web_artist:
+        return
+
+    return models.Artist(uri=web_artist["uri"], name=web_artist.get("name"))
 
 
 def web_to_album(web_album):
-    artists = [web_to_artist(web_artist) for web_artist in web_album["artists"]]
+    if "uri" not in web_album:
+        return
+
+    artists = [
+        web_to_artist(web_artist) for web_artist in web_album.get("artists", [])
+    ]
+    artists = [a for a in artists if a]
 
     return models.Album(
-        uri=web_album["uri"], name=web_album["name"], artists=artists
+        uri=web_album["uri"], name=web_album.get("name"), artists=artists
     )
 
 
-def web_to_track(web_track):
-    artists = [web_to_artist(web_artist) for web_artist in web_track["artists"]]
-    album = web_to_album(web_track["album"])
+def web_to_track(web_track, bitrate=None):
+    if web_track.get("type") != "track":
+        return
+
+    # TODO: Check availability
+
+    artists = [
+        web_to_artist(web_artist) for web_artist in web_track.get("artists", [])
+    ]
+    artists = [a for a in artists if a]
+
+    album = web_to_album(web_track.get("album", {}))
 
     return models.Track(
-        uri=web_track["uri"],
-        name=web_track["name"],
+        uri=web_track.get("uri"),
+        name=web_track.get("name"),
         artists=artists,
         album=album,
-        length=web_track["duration_ms"],
-        disc_no=web_track["disc_number"],
-        track_no=web_track["track_number"],
+        length=web_track.get("duration_ms"),
+        disc_no=web_track.get("disc_number"),
+        track_no=web_track.get("track_number"),
+        bitrate=bitrate,
     )

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -97,9 +97,7 @@ def to_track(sp_track, bitrate=None):
         return
 
     if sp_track.error != spotify.ErrorType.OK:
-        logger.debug(
-            f"Error loading {sp_track.link.uri}: {repr(sp_track.error)}"
-        )
+        logger.debug(f"Error loading {sp_track.link.uri!r}: {sp_track.error!r}")
         return
 
     if sp_track.availability != spotify.TrackAvailability.AVAILABLE:
@@ -129,9 +127,7 @@ def to_track_ref(sp_track):
         return
 
     if sp_track.error != spotify.ErrorType.OK:
-        logger.debug(
-            f"Error loading {sp_track.link.uri}: {repr(sp_track.error)}"
-        )
+        logger.debug(f"Error loading {sp_track.link.uri!r}: {sp_track.error!r}")
         return
 
     if sp_track.availability != spotify.TrackAvailability.AVAILABLE:
@@ -161,7 +157,7 @@ def web_to_track_ref(web_track):
     uri = web_track.get("linked_from", {}).get("uri") or web_track["uri"]
 
     if not web_track.get("is_playable", False):
-        logger.debug(f"{uri} is not playable")
+        logger.debug(f"{uri!r} is not playable")
         return
 
     return models.Ref.track(uri=uri, name=web_track.get("name"))

--- a/mopidy_spotify/utils.py
+++ b/mopidy_spotify/utils.py
@@ -3,8 +3,8 @@ import logging
 import time
 
 import requests
-
 from mopidy import httpclient
+
 from mopidy_spotify import Extension, __version__
 
 logger = logging.getLogger(__name__)

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -403,7 +403,7 @@ class SpotifyOAuthClient(OAuthClient):
         self._extra_expiry = self.DEFAULT_EXTRA_EXPIRY
 
     def get_one(self, path, *args, **kwargs):
-        logger.debug(f"Fetching page {path!r}")
+        _trace(f"Fetching page {path!r}")
         result = self.get(path, cache=self._cache, *args, **kwargs)
         result.increase_expiry(self._extra_expiry)
         return result
@@ -428,10 +428,9 @@ class SpotifyOAuthClient(OAuthClient):
         return self.user_id is not None
 
     def get_user_playlists(self):
-        with utils.time_logger("get_user_playlists"):
-            pages = self.get_all("me/playlists", params={"limit": 50})
-            for page in pages:
-                yield from page.get("items", [])
+        pages = self.get_all("me/playlists", params={"limit": 50})
+        for page in pages:
+            yield from page.get("items", [])
 
     def get_playlist(self, uri):
         try:

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -390,7 +390,7 @@ class SpotifyOAuthClient(OAuthClient):
     )
     DEFAULT_EXTRA_EXPIRY = 10
 
-    def __init__(self, client_id, client_secret, proxy_config):
+    def __init__(self, *, client_id, client_secret, proxy_config):
         super().__init__(
             base_url="https://api.spotify.com/v1",
             refresh_url="https://auth.mopidy.com/spotify/token",

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -1,3 +1,5 @@
+import collections
+import copy
 import email
 import logging
 import os
@@ -356,9 +358,16 @@ class WebResponse(dict):
 
 
 class SpotifyOAuthClient(OAuthClient):
+
+    TRACK_FIELDS = (
+        "next,items(track(type,uri,name,duration_ms,disc_number,track_number,"
+        "artists,album,is_playable,linked_from.uri))"
+    )
+    PLAYLIST_FIELDS = (
+        f"name,owner.id,type,uri,snapshot_id,tracks({TRACK_FIELDS}),"
+    )
+
     def __init__(self, client_id, client_secret, proxy_config):
-        self.user_name = None
-        self.user_country = None
         super(SpotifyOAuthClient, self).__init__(
             base_url="https://api.spotify.com/v1",
             refresh_url="https://auth.mopidy.com/spotify/token",
@@ -366,14 +375,97 @@ class SpotifyOAuthClient(OAuthClient):
             client_secret=client_secret,
             proxy_config=proxy_config,
         )
+        self.user_id = None
+
+    def get_all(self, path, *args, **kwargs):
+        while path is not None:
+            logger.debug(f'Fetching page "{path}"')
+            result = self.get(path, *args, **kwargs)
+            path = result.get("next")
+            yield result
 
     def login(self):
-        user_profile = self.get("me")
-        if user_profile is None:
+        self.user_id = self.get("me").get("id")
+        if self.user_id is None:
             logger.error("Failed to load Spotify user profile")
             return False
         else:
-            self.user_name = user_profile.get("id")
-            self.user_country = user_profile.get("country")
-            logger.info(f"Logged into Spotify Web API as {self.user_name}")
+            logger.info(f"Logged into Spotify Web API as {self.user_id}")
             return True
+
+    def get_user_playlists(self, cache=None):
+        with utils.time_logger("get_user_playlists"):
+            pages = self.get_all(
+                "me/playlists", cache=cache, params={"limit": 50}
+            )
+            for page in pages:
+                for playlist in page.get("items", []):
+                    yield playlist
+
+    def get_playlist(self, uri, cache=None):
+        try:
+            parsed = parse_uri(uri)
+            if parsed.type != "playlist":
+                raise ValueError(
+                    f"Could not parse {repr(uri)} as a Spotify playlist URI"
+                )
+        except ValueError as exc:
+            logger.error(exc)
+            return {}
+
+        playlist = self.get(
+            f"playlists/{parsed.id}",
+            cache=cache,
+            params={"fields": self.PLAYLIST_FIELDS, "market": "from_token"},
+        )
+
+        tracks_path = playlist.get("tracks", {}).get("next")
+        track_pages = self.get_all(
+            tracks_path,
+            cache=cache,
+            params={"fields": self.TRACK_FIELDS, "market": "from_token"},
+        )
+
+        more_tracks = []
+        for page in track_pages:
+            more_tracks += page.get("items", [])
+        if more_tracks:
+            # Take a copy to avoid changing the cached response.
+            playlist = copy.deepcopy(playlist)
+            playlist.setdefault("tracks", {}).setdefault("items", [])
+            playlist["tracks"]["items"] += more_tracks
+
+        return playlist
+
+
+WebLink = collections.namedtuple("WebLink", ["uri", "type", "id", "owner"])
+
+
+# TODO: Make a WebSession class method?
+def parse_uri(uri):
+    parsed_uri = urllib.parse.urlparse(uri)
+
+    schemes = ("http", "https")
+    netlocs = ("open.spotify.com", "play.spotify.com")
+
+    if parsed_uri.scheme == "spotify":
+        parts = parsed_uri.path.split(":")
+    elif parsed_uri.scheme in schemes and parsed_uri.netloc in netlocs:
+        parts = parsed_uri.path[1:].split("/")
+    else:
+        parts = []
+
+    # Strip out empty parts to ensure we are strict about URI parsing.
+    parts = [p for p in parts if p.strip()]
+
+    if len(parts) == 2 and parts[0] in ("track", "album", "artist", "playlist"):
+        return WebLink(uri, parts[0], parts[1], None)
+    elif len(parts) == 3 and parts[0] == "user" and parts[2] == "starred":
+        if parsed_uri.scheme == "spotify":
+            return WebLink(uri, "playlist", None, parts[1])
+    elif len(parts) == 3 and parts[0] == "playlist":
+        return WebLink(uri, "playlist", parts[2], parts[1])
+    elif len(parts) == 4 and parts[0] == "user" and parts[2] == "playlist":
+        return WebLink(uri, "playlist", parts[3], parts[1])
+
+    raise ValueError(f"Could not parse {repr(uri)} as a Spotify URI")

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -352,8 +352,9 @@ class WebResponse(dict):
 
     def __str__(self):
         return (
-            f"URL: {self.url} ETag: {self._etag} "
-            f"Expires: {datetime.fromtimestamp(self._expires)}"
+            f"URL: {self.url} "
+            f"expires at: {datetime.fromtimestamp(self._expires)} "
+            f"[ETag: {self._etag}]"
         )
 
 

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -353,3 +353,27 @@ class WebResponse(dict):
             f"URL: {self.url} ETag: {self._etag} "
             f"Expires: {datetime.fromtimestamp(self._expires)}"
         )
+
+
+class SpotifyOAuthClient(OAuthClient):
+    def __init__(self, client_id, client_secret, proxy_config):
+        self.user_name = None
+        self.user_country = None
+        super(SpotifyOAuthClient, self).__init__(
+            base_url="https://api.spotify.com/v1",
+            refresh_url="https://auth.mopidy.com/spotify/token",
+            client_id=client_id,
+            client_secret=client_secret,
+            proxy_config=proxy_config,
+        )
+
+    def login(self):
+        user_profile = self.get("me")
+        if user_profile is None:
+            logger.error("Failed to load Spotify user profile")
+            return False
+        else:
+            self.user_name = user_profile.get("id")
+            self.user_country = user_profile.get("country")
+            logger.info(f"Logged into Spotify Web API as {self.user_name}")
+            return True

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -389,7 +389,7 @@ class SpotifyOAuthClient(OAuthClient):
     DEFAULT_EXTRA_EXPIRY = 10
 
     def __init__(self, client_id, client_secret, proxy_config):
-        super(SpotifyOAuthClient, self).__init__(
+        super().__init__(
             base_url="https://api.spotify.com/v1",
             refresh_url="https://auth.mopidy.com/spotify/token",
             client_id=client_id,
@@ -429,8 +429,7 @@ class SpotifyOAuthClient(OAuthClient):
         with utils.time_logger("get_user_playlists"):
             pages = self.get_all("me/playlists", params={"limit": 50})
             for page in pages:
-                for playlist in page.get("items", []):
-                    yield playlist
+                yield from page.get("items", [])
 
     def get_playlist(self, uri):
         try:

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -6,6 +6,7 @@ import os
 import re
 import time
 import urllib.parse
+from contextlib import contextmanager
 from datetime import datetime
 
 import requests
@@ -377,6 +378,7 @@ class SpotifyOAuthClient(OAuthClient):
             proxy_config=proxy_config,
         )
         self.user_id = None
+        self._cache = {}
 
     def get_all(self, path, *args, **kwargs):
         while path is not None:
@@ -394,16 +396,16 @@ class SpotifyOAuthClient(OAuthClient):
             logger.info(f"Logged into Spotify Web API as {self.user_id}")
             return True
 
-    def get_user_playlists(self, cache=None):
+    def get_user_playlists(self):
         with utils.time_logger("get_user_playlists"):
             pages = self.get_all(
-                "me/playlists", cache=cache, params={"limit": 50}
+                "me/playlists", cache=self._cache, params={"limit": 50}
             )
             for page in pages:
                 for playlist in page.get("items", []):
                     yield playlist
 
-    def get_playlist(self, uri, cache=None):
+    def get_playlist(self, uri):
         try:
             parsed = parse_uri(uri)
             if parsed.type != "playlist":
@@ -416,14 +418,14 @@ class SpotifyOAuthClient(OAuthClient):
 
         playlist = self.get(
             f"playlists/{parsed.id}",
-            cache=cache,
+            cache=self._cache,
             params={"fields": self.PLAYLIST_FIELDS, "market": "from_token"},
         )
 
         tracks_path = playlist.get("tracks", {}).get("next")
         track_pages = self.get_all(
             tracks_path,
-            cache=cache,
+            cache=self._cache,
             params={"fields": self.TRACK_FIELDS, "market": "from_token"},
         )
 
@@ -437,6 +439,15 @@ class SpotifyOAuthClient(OAuthClient):
             playlist["tracks"]["items"] += more_tracks
 
         return playlist
+
+    @contextmanager
+    def refresh_playlists(self, extra_expiry=None):
+        self._cache.clear()
+        old_extra_expiry = self._extra_expiry
+        if extra_expiry is not None:
+            self._extra_expiry = extra_expiry
+        yield
+        self._extra_expiry = old_extra_expiry
 
 
 WebLink = collections.namedtuple("WebLink", ["uri", "type", "id", "owner"])

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -401,7 +401,7 @@ class SpotifyOAuthClient(OAuthClient):
         self._extra_expiry = self.DEFAULT_EXTRA_EXPIRY
 
     def get_one(self, path, *args, **kwargs):
-        logger.debug(f'Fetching page "{path}"')
+        logger.debug(f"Fetching page {path!r}")
         result = self.get(path, cache=self._cache, *args, **kwargs)
         result.increase_expiry(self._extra_expiry)
         return result
@@ -436,7 +436,7 @@ class SpotifyOAuthClient(OAuthClient):
             parsed = parse_uri(uri)
             if parsed.type != "playlist":
                 raise ValueError(
-                    f"Could not parse {repr(uri)} as a Spotify playlist URI"
+                    f"Could not parse {uri!r} as a Spotify playlist URI"
                 )
         except ValueError as exc:
             logger.error(exc)
@@ -499,4 +499,4 @@ def parse_uri(uri):
     elif len(parts) == 4 and parts[0] == "user" and parts[2] == "playlist":
         return WebLink(uri, "playlist", parts[3], parts[1])
 
-    raise ValueError(f"Could not parse {repr(uri)} as a Spotify URI")
+    raise ValueError(f"Could not parse {uri!r} as a Spotify URI")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -306,7 +306,7 @@ def web_search_mock_large(web_album_mock, web_artist_mock, web_track_mock):
 
 @pytest.fixture
 def web_artist_mock():
-    return {"name": "ABBA", "uri": "spotify:artist:abba"}
+    return {"name": "ABBA", "uri": "spotify:artist:abba", "type": "artist"}
 
 
 @pytest.fixture
@@ -314,6 +314,7 @@ def web_album_mock(web_artist_mock):
     return {
         "name": "DEF 456",
         "uri": "spotify:album:def",
+        "type": "album",
         "artists": [web_artist_mock],
     }
 
@@ -329,6 +330,7 @@ def web_track_mock(web_artist_mock, web_album_mock):
         "track_number": 7,
         "uri": "spotify:track:abc",
         "type": "track",
+        "is_playable": True,
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
 from unittest import mock
 
 import pytest
-import spotify
-
 from mopidy import backend as backend_api
 from mopidy import models
+
+import spotify
 from mopidy_spotify import backend, library, utils, web
 
 
@@ -328,6 +328,7 @@ def web_track_mock(web_artist_mock, web_album_mock):
         "name": "ABC 123",
         "track_number": 7,
         "uri": "spotify:track:abc",
+        "type": "track",
     }
 
 
@@ -363,6 +364,18 @@ def web_oauth_mock():
 
 
 @pytest.fixture
+def web_playlist_mock(web_track_mock):
+    return {
+        "owner": {"id": "alice"},
+        "name": "Foo",
+        "tracks": {"items": [{"track": web_track_mock}]},
+        "snapshot_id": "abcderfg12364",
+        "uri": "spotify:user:alice:playlist:foo",
+        "type": "playlist",
+    }
+
+
+@pytest.fixture
 def mopidy_artist_mock():
     return models.Artist(name="ABBA", uri="spotify:artist:abba")
 
@@ -381,16 +394,14 @@ def mopidy_album_mock(mopidy_artist_mock):
 def session_mock():
     sp_session_mock = mock.Mock(spec=spotify.Session)
     sp_session_mock.connection.state = spotify.ConnectionState.LOGGED_IN
-    sp_session_mock.playlist_container = []
-    sp_session_mock.user_country = "GB"
     return sp_session_mock
 
 
 @pytest.fixture
 def web_client_mock():
     web_client_mock = mock.Mock(spec=web.SpotifyOAuthClient)
-    web_client_mock.user_name = "Jane Doe"
-    web_client_mock.user_country = "GB"
+    web_client_mock.user_id = "alice"
+    web_client_mock.get_user_playlists.return_value = []
     return web_client_mock
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -401,7 +401,7 @@ def session_mock():
 
 @pytest.fixture
 def web_client_mock():
-    web_client_mock = mock.Mock(spec=web.SpotifyOAuthClient)
+    web_client_mock = mock.MagicMock(spec=web.SpotifyOAuthClient)
     web_client_mock.user_id = "alice"
     web_client_mock.get_user_playlists.return_value = []
     return web_client_mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,14 @@ def config(tmp_path):
 
 
 @pytest.yield_fixture
-def spotify_mock():
+def web_mock():
+    patcher = mock.patch.object(backend, "web", spec=web)
+    yield patcher.start()
+    patcher.stop()
+
+
+@pytest.yield_fixture
+def spotify_mock(web_mock):
     patcher = mock.patch.object(backend, "spotify", spec=spotify)
     yield patcher.start()
     patcher.stop()
@@ -381,7 +388,9 @@ def session_mock():
 
 @pytest.fixture
 def web_client_mock():
-    web_client_mock = mock.Mock(spec=web.OAuthClient)
+    web_client_mock = mock.Mock(spec=web.SpotifyOAuthClient)
+    web_client_mock.user_name = "Jane Doe"
+    web_client_mock.user_country = "GB"
     return web_client_mock
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -186,6 +186,7 @@ def test_on_start_refreshes_playlists(spotify_mock, web_mock, config, caplog):
     client_mock = web_mock.SpotifyOAuthClient.return_value
     client_mock.get_user_playlists.assert_called_once()
     assert "Refreshed 0 playlists" in caplog.text
+    assert backend.playlists._loaded
 
 
 def test_on_start_doesnt_refresh_playlists_if_not_allowed(

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,9 +1,9 @@
 import threading
 from unittest import mock
 
-import spotify
-
 from mopidy import backend as backend_api
+
+import spotify
 from mopidy_spotify import backend, library, playback, playlists
 
 
@@ -13,7 +13,6 @@ def get_backend(config, session_mock=None):
         obj._session = session_mock
     else:
         obj._session = mock.Mock()
-        obj._session.playlist_container = None
         obj._web_client = mock.Mock()
     obj._event_loop = mock.Mock()
     return obj
@@ -117,9 +116,7 @@ def test_on_start_configures_proxy(spotify_mock, web_mock, config):
     assert spotify_config.proxy_password == "s3cret"
 
     web_mock.SpotifyOAuthClient.assert_called_once_with(
-        mock.ANY,
-        mock.ANY,
-        config['proxy'],
+        mock.ANY, mock.ANY, config["proxy"],
     )
 
 
@@ -131,7 +128,7 @@ def test_on_start_configures_web_client(spotify_mock, web_mock, config):
     backend.on_start()
 
     web_mock.SpotifyOAuthClient.assert_called_once_with(
-        '1234567', 'AbCdEfG', mock.ANY,
+        "1234567", "AbCdEfG", mock.ANY,
     )
 
 
@@ -272,68 +269,6 @@ def test_on_logged_in_event_activates_private_session(
 
     assert "Spotify private session activated" in caplog.text
     private_session_mock.assert_called_once_with(True)
-
-
-def test_on_logged_in_event_adds_playlist_container_loaded_handler(
-    spotify_mock, config
-):
-    session_mock = spotify_mock.Session.return_value
-    backend = get_backend(config, session_mock)
-
-    backend.on_logged_in()
-
-    assert (
-        mock.call(
-            spotify_mock.PlaylistContainerEvent.CONTAINER_LOADED,
-            playlists.on_container_loaded,
-        )
-        in session_mock.playlist_container.on.call_args_list
-    )
-
-
-def test_on_logged_in_event_adds_playlist_added_handler(spotify_mock, config):
-    session_mock = spotify_mock.Session.return_value
-    backend = get_backend(config, session_mock)
-
-    backend.on_logged_in()
-
-    assert (
-        mock.call(
-            spotify_mock.PlaylistContainerEvent.PLAYLIST_ADDED,
-            playlists.on_playlist_added,
-        )
-        in session_mock.playlist_container.on.call_args_list
-    )
-
-
-def test_on_logged_in_event_adds_playlist_removed_handler(spotify_mock, config):
-    session_mock = spotify_mock.Session.return_value
-    backend = get_backend(config, session_mock)
-
-    backend.on_logged_in()
-
-    assert (
-        mock.call(
-            spotify_mock.PlaylistContainerEvent.PLAYLIST_REMOVED,
-            playlists.on_playlist_removed,
-        )
-        in session_mock.playlist_container.on.call_args_list
-    )
-
-
-def test_on_logged_in_event_adds_playlist_moved_handler(spotify_mock, config):
-    session_mock = spotify_mock.Session.return_value
-    backend = get_backend(config, session_mock)
-
-    backend.on_logged_in()
-
-    assert (
-        mock.call(
-            spotify_mock.PlaylistContainerEvent.PLAYLIST_MOVED,
-            playlists.on_playlist_moved,
-        )
-        in session_mock.playlist_container.on.call_args_list
-    )
 
 
 def test_on_play_token_lost_messages_the_actor(spotify_mock, caplog):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -116,7 +116,9 @@ def test_on_start_configures_proxy(spotify_mock, web_mock, config):
     assert spotify_config.proxy_password == "s3cret"
 
     web_mock.SpotifyOAuthClient.assert_called_once_with(
-        mock.ANY, mock.ANY, config["proxy"],
+        client_id=mock.ANY,
+        client_secret=mock.ANY,
+        proxy_config=config["proxy"],
     )
 
 
@@ -128,7 +130,7 @@ def test_on_start_configures_web_client(spotify_mock, web_mock, config):
     backend.on_start()
 
     web_mock.SpotifyOAuthClient.assert_called_once_with(
-        "1234567", "AbCdEfG", mock.ANY,
+        client_id="1234567", client_secret="AbCdEfG", proxy_config=mock.ANY,
     )
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -185,7 +185,7 @@ def test_on_start_refreshes_playlists(spotify_mock, web_mock, config, caplog):
 
     client_mock = web_mock.SpotifyOAuthClient.return_value
     client_mock.get_user_playlists.assert_called_once()
-    assert "Refreshed 0 playlists" in caplog.text
+    assert "Refreshed 0 Spotify playlists" in caplog.text
     assert backend.playlists._loaded
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -179,6 +179,28 @@ def test_on_start_logs_in(spotify_mock, web_mock, config):
     web_mock.SpotifyOAuthClient.return_value.login.assert_called_once()
 
 
+def test_on_start_refreshes_playlists(spotify_mock, web_mock, config, caplog):
+    backend = get_backend(config)
+    backend.on_start()
+
+    client_mock = web_mock.SpotifyOAuthClient.return_value
+    client_mock.get_user_playlists.assert_called_once()
+    assert "Refreshed 0 playlists" in caplog.text
+
+
+def test_on_start_doesnt_refresh_playlists_if_not_allowed(
+    spotify_mock, web_mock, config, caplog
+):
+    config["spotify"]["allow_playlists"] = False
+
+    backend = get_backend(config)
+    backend.on_start()
+
+    client_mock = web_mock.SpotifyOAuthClient.return_value
+    client_mock.get_user_playlists.assert_not_called()
+    assert "Refreshed 0 playlists" not in caplog.text
+
+
 def test_on_stop_logs_out_and_waits_for_logout_to_complete(
     spotify_mock, config, caplog
 ):

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -1,8 +1,8 @@
 from unittest import mock
 
-import spotify
-
 from mopidy import models
+
+import spotify
 
 
 def test_has_a_root_directory(provider):

--- a/tests/test_distinct.py
+++ b/tests/test_distinct.py
@@ -1,8 +1,8 @@
 from unittest import mock
 
 import pytest
-
 from mopidy import models
+
 from mopidy_spotify import distinct, search
 
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,6 +1,6 @@
 import pytest
-
 from mopidy import models
+
 from mopidy_spotify import images
 
 

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -3,13 +3,30 @@ from unittest import mock
 import spotify
 
 
-def test_lookup_of_invalid_uri(session_mock, provider, caplog):
-    session_mock.get_link.side_effect = ValueError("an error message")
-
+def test_lookup_of_invalid_uri(provider, caplog):
     results = provider.lookup("invalid")
 
     assert len(results) == 0
-    assert 'Failed to lookup "invalid": an error message' in caplog.text
+    assert 'Failed to lookup "invalid": Could not parse' in caplog.text
+
+
+def test_lookup_of_invalid_playlist_uri(provider, caplog):
+    results = provider.lookup("spotify:playlist")
+
+    assert len(results) == 0
+    assert 'Failed to lookup "spotify:playlist": Could not parse' in caplog.text
+
+
+def test_lookup_of_invalid_track_uri(session_mock, provider, caplog):
+    session_mock.get_link.side_effect = ValueError("an error message")
+
+    results = provider.lookup("spotify:track:invalid")
+
+    assert len(results) == 0
+    assert (
+        'Failed to lookup "spotify:track:invalid": an error message'
+        in caplog.text
+    )
 
 
 def test_lookup_of_unhandled_uri(session_mock, provider, caplog):
@@ -17,12 +34,12 @@ def test_lookup_of_unhandled_uri(session_mock, provider, caplog):
     sp_link_mock.type = spotify.LinkType.INVALID
     session_mock.get_link.return_value = sp_link_mock
 
-    results = provider.lookup("something")
+    results = provider.lookup("spotify:artist:something")
 
     assert len(results) == 0
     assert (
-        'Failed to lookup "something": Cannot handle <LinkType.INVALID: 0>'
-        in caplog.text
+        'Failed to lookup "spotify:artist:something": '
+        "Cannot handle <LinkType.INVALID: 0>" in caplog.text
     )
 
 
@@ -143,34 +160,20 @@ def test_lookup_of_artist_uri_ignores_various_artists_albums(
     assert len(results) == 0
 
 
-def test_lookup_of_playlist_uri(session_mock, sp_playlist_mock, provider):
-    session_mock.get_link.return_value = sp_playlist_mock.link
+def test_lookup_of_playlist_uri(
+    session_mock, web_client_mock, web_playlist_mock, provider
+):
+    web_client_mock.get_playlist.return_value = web_playlist_mock
 
     results = provider.lookup("spotify:playlist:alice:foo")
 
-    session_mock.get_link.assert_called_once_with("spotify:playlist:alice:foo")
-    sp_playlist_mock.link.as_playlist.assert_called_once_with()
-    sp_playlist_mock.load.assert_called_once_with(10)
-    sp_playlist_mock.tracks[0].load.assert_called_once_with(10)
+    session_mock.get_link.assert_not_called()
+    web_client_mock.get_playlist.assert_called_once_with(
+        "spotify:playlist:alice:foo", {}
+    )
 
     assert len(results) == 1
     track = results[0]
     assert track.uri == "spotify:track:abc"
     assert track.name == "ABC 123"
-    assert track.bitrate == 160
-
-
-def test_lookup_of_starred_uri(session_mock, sp_starred_mock, provider):
-    session_mock.get_link.return_value = sp_starred_mock.link
-
-    results = provider.lookup("spotify:user:alice:starred")
-
-    session_mock.get_link.assert_called_once_with("spotify:user:alice:starred")
-    sp_starred_mock.link.as_playlist.assert_called_once_with()
-    sp_starred_mock.load.assert_called_once_with(10)
-
-    assert len(results) == 2
-    track = results[0]
-    assert track.uri == "spotify:track:newest"
-    assert track.name == "Newest"
     assert track.bitrate == 160

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -161,13 +161,14 @@ def test_lookup_of_artist_uri_ignores_various_artists_albums(
 
 
 def test_lookup_of_playlist_uri(
-    session_mock, web_client_mock, web_playlist_mock, provider
+    session_mock, web_client_mock, web_playlist_mock, sp_track_mock, provider
 ):
     web_client_mock.get_playlist.return_value = web_playlist_mock
+    session_mock.get_link.return_value = sp_track_mock.link
 
     results = provider.lookup("spotify:playlist:alice:foo")
 
-    session_mock.get_link.assert_not_called()
+    session_mock.get_link.assert_called_once_with("spotify:track:abc")
     web_client_mock.get_playlist.assert_called_once_with(
         "spotify:playlist:alice:foo", {}
     )

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -7,14 +7,14 @@ def test_lookup_of_invalid_uri(provider, caplog):
     results = provider.lookup("invalid")
 
     assert len(results) == 0
-    assert 'Failed to lookup "invalid": Could not parse' in caplog.text
+    assert "Failed to lookup 'invalid': Could not parse" in caplog.text
 
 
 def test_lookup_of_invalid_playlist_uri(provider, caplog):
     results = provider.lookup("spotify:playlist")
 
     assert len(results) == 0
-    assert 'Failed to lookup "spotify:playlist": Could not parse' in caplog.text
+    assert "Failed to lookup 'spotify:playlist': Could not parse" in caplog.text
 
 
 def test_lookup_of_invalid_track_uri(session_mock, provider, caplog):
@@ -24,7 +24,7 @@ def test_lookup_of_invalid_track_uri(session_mock, provider, caplog):
 
     assert len(results) == 0
     assert (
-        'Failed to lookup "spotify:track:invalid": an error message'
+        "Failed to lookup 'spotify:track:invalid': an error message"
         in caplog.text
     )
 
@@ -38,7 +38,7 @@ def test_lookup_of_unhandled_uri(session_mock, provider, caplog):
 
     assert len(results) == 0
     assert (
-        'Failed to lookup "spotify:artist:something": '
+        "Failed to lookup 'spotify:artist:something': "
         "Cannot handle <LinkType.INVALID: 0>" in caplog.text
     )
 
@@ -53,7 +53,7 @@ def test_lookup_when_offline(session_mock, sp_track_mock, provider, caplog):
 
     assert len(results) == 0
     assert (
-        'Failed to lookup "spotify:track:abc": Must be online to load objects'
+        "Failed to lookup 'spotify:track:abc': Must be online to load objects"
         in caplog.text
     )
 
@@ -189,6 +189,6 @@ def test_lookup_of_playlist_uri_when_not_logged_in(
 
     assert len(results) == 0
     assert (
-        'Failed to lookup "spotify:playlist:alice:foo": '
+        "Failed to lookup 'spotify:playlist:alice:foo': "
         "Playlist Web API lookup failed" in caplog.text
     )

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -170,7 +170,7 @@ def test_lookup_of_playlist_uri(
 
     session_mock.get_link.assert_called_once_with("spotify:track:abc")
     web_client_mock.get_playlist.assert_called_once_with(
-        "spotify:playlist:alice:foo", {}
+        "spotify:playlist:alice:foo"
     )
 
     assert len(results) == 1
@@ -178,3 +178,17 @@ def test_lookup_of_playlist_uri(
     assert track.uri == "spotify:track:abc"
     assert track.name == "ABC 123"
     assert track.bitrate == 160
+
+
+def test_lookup_of_playlist_uri_when_not_logged_in(
+    web_client_mock, provider, caplog
+):
+    web_client_mock.user_id = None
+
+    results = provider.lookup("spotify:playlist:alice:foo")
+
+    assert len(results) == 0
+    assert (
+        'Failed to lookup "spotify:playlist:alice:foo": '
+        "Playlist Web API lookup failed" in caplog.text
+    )

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -2,11 +2,11 @@ import threading
 from unittest import mock
 
 import pytest
-import spotify
-
 from mopidy import audio
 from mopidy import backend as backend_api
 from mopidy import models
+
+import spotify
 from mopidy_spotify import backend, playback
 
 

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -25,6 +25,7 @@ def web_client_mock(web_client_mock, web_track_mock):
         "name": "Malformed",
         "tracks": {"items": []},
         "uri": "spotify:user:alice:playlist:malformed",
+        "type": "bogus",
     }
     web_playlists = [web_playlist1, web_playlist2, web_playlist3]
     web_playlists_map = {x["uri"]: x for x in web_playlists}
@@ -63,7 +64,7 @@ def test_as_list_when_offline(web_client_mock, provider):
     assert len(result) == 0
 
 
-def test_as_list_when_playlist_malformed(provider, caplog):
+def test_as_list_when_playlist_wont_translate(provider, caplog):
     result = provider.as_list()
 
     assert len(result) == 2
@@ -74,8 +75,6 @@ def test_as_list_when_playlist_malformed(provider, caplog):
     assert result[1] == Ref.playlist(
         uri="spotify:user:bob:playlist:baz", name="Baz (by bob)"
     )
-
-    assert "No playlist data present" in caplog.text
 
 
 def test_as_list_uses_cache(provider, web_client_mock):
@@ -100,9 +99,8 @@ def test_get_items_when_playlist_without_tracks(provider):
     assert result == []
 
 
-def test_get_items_when_playlist_is_malformed(provider, caplog):
+def test_get_items_when_playlist_wont_translate(provider, caplog):
     assert provider.get_items("spotify:user:alice:playlist:malformed") is None
-    assert "No playlist data present" in caplog.text
 
 
 def test_get_items_when_playlist_is_unknown(provider, caplog):

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -1,56 +1,45 @@
-from unittest import mock
-
 import pytest
-import spotify
-
 from mopidy import backend as backend_api
 from mopidy.models import Ref
-from mopidy_spotify import backend, playlists
+
+from mopidy_spotify import playlists
 
 
 @pytest.fixture
-def session_mock(
-    sp_playlist_mock,
-    sp_playlist_folder_start_mock,
-    sp_playlist_folder_end_mock,
-    sp_user_mock,
-):
+def web_client_mock(web_client_mock, web_track_mock):
+    web_playlist1 = {
+        "owner": {"id": "alice"},
+        "name": "Foo",
+        "tracks": {"items": [{"track": web_track_mock}]},
+        "uri": "spotify:user:alice:playlist:foo",
+        "type": "playlist",
+    }
+    web_playlist2 = {
+        "owner": {"id": "bob"},
+        "name": "Baz",
+        "uri": "spotify:user:bob:playlist:baz",
+        "type": "playlist",
+    }
+    web_playlist3 = {
+        "owner": {"id": "alice"},
+        "name": "Malformed",
+        "tracks": {"items": []},
+        "uri": "spotify:user:alice:playlist:malformed",
+    }
+    web_playlists = [web_playlist1, web_playlist2, web_playlist3]
+    web_playlists_map = {x["uri"]: x for x in web_playlists}
 
-    sp_playlist2_mock = mock.Mock(spec=spotify.Playlist)
-    sp_playlist2_mock.is_loaded = True
-    sp_playlist2_mock.owner = mock.Mock(spec=spotify.User)
-    sp_playlist2_mock.owner.canonical_name = "bob"
-    sp_playlist2_mock.link.uri = "spotify:playlist:bob:baz"
-    sp_playlist2_mock.name = "Baz"
-    sp_playlist2_mock.tracks = []
+    def get_playlist(*args, **kwargs):
+        return web_playlists_map.get(args[0], {})
 
-    sp_playlist3_mock = mock.Mock(spec=spotify.Playlist)
-    sp_playlist3_mock.is_loaded = False
-
-    sp_session_mock = mock.Mock(spec=spotify.Session)
-    sp_session_mock.user = sp_user_mock
-    sp_session_mock.user_name = "alice"
-    sp_session_mock.playlist_container = [
-        sp_playlist_mock,
-        sp_playlist_folder_start_mock,
-        sp_playlist2_mock,
-        sp_playlist_folder_end_mock,
-        sp_playlist3_mock,
-    ]
-    return sp_session_mock
-
-
-@pytest.fixture
-def backend_mock(session_mock, config):
-    backend_mock = mock.Mock(spec=backend.SpotifyBackend)
-    backend_mock._config = config
-    backend_mock._session = session_mock
-    backend_mock._bitrate = 160
-    return backend_mock
+    web_client_mock.get_user_playlists.return_value = web_playlists
+    web_client_mock.get_playlist.side_effect = get_playlist
+    return web_client_mock
 
 
 @pytest.fixture
-def provider(backend_mock):
+def provider(backend_mock, web_client_mock):
+    backend_mock._web_client = web_client_mock
     return playlists.SpotifyPlaylistsProvider(backend_mock)
 
 
@@ -58,31 +47,23 @@ def test_is_a_playlists_provider(provider):
     assert isinstance(provider, backend_api.PlaylistsProvider)
 
 
-def test_as_list_when_not_logged_in(session_mock, provider):
-    session_mock.playlist_container = None
+def test_as_list_when_not_logged_in(web_client_mock, provider):
+    web_client_mock.user_id = None
 
     result = provider.as_list()
 
     assert len(result) == 0
 
 
-def test_as_list_when_offline(session_mock, provider):
-    session_mock.connection.state = spotify.ConnectionState.OFFLINE
-
-    result = provider.as_list()
-
-    assert len(result) == 2
-
-
-def test_as_list_when_playlist_container_isnt_loaded(session_mock, provider):
-    session_mock.playlist_container = None
+def test_as_list_when_offline(web_client_mock, provider):
+    web_client_mock.get_user_playlists.return_value = {}
 
     result = provider.as_list()
 
     assert len(result) == 0
 
 
-def test_as_list_with_folders_and_ignored_unloaded_playlist(provider):
+def test_as_list_when_playlist_malformed(provider, caplog):
     result = provider.as_list()
 
     assert len(result) == 2
@@ -91,15 +72,19 @@ def test_as_list_with_folders_and_ignored_unloaded_playlist(provider):
         uri="spotify:user:alice:playlist:foo", name="Foo"
     )
     assert result[1] == Ref.playlist(
-        uri="spotify:playlist:bob:baz", name="Bar/Baz (by bob)"
+        uri="spotify:user:bob:playlist:baz", name="Baz (by bob)"
     )
 
+    assert "No playlist data present" in caplog.text
 
-def test_get_items_when_playlist_exists(
-    session_mock, sp_playlist_mock, provider
-):
-    session_mock.get_playlist.return_value = sp_playlist_mock
 
+def test_as_list_uses_cache(provider, web_client_mock):
+    provider.as_list()
+
+    web_client_mock.get_user_playlists.assert_called_once_with(playlists._cache)
+
+
+def test_get_items_when_playlist_exists(provider):
     result = provider.get_items("spotify:user:alice:playlist:foo")
 
     assert len(result) == 1
@@ -107,15 +92,36 @@ def test_get_items_when_playlist_exists(
     assert result[0] == Ref.track(uri="spotify:track:abc", name="ABC 123")
 
 
-def test_get_items_when_playlist_is_unknown(provider):
-    result = provider.get_items("spotify:user:alice:playlist:unknown")
+def test_get_items_when_playlist_without_tracks(provider):
+    result = provider.get_items("spotify:user:bob:playlist:baz")
 
-    assert result is None
+    assert len(result) == 0
+
+    assert result == []
 
 
-def test_lookup(session_mock, sp_playlist_mock, provider):
-    session_mock.get_playlist.return_value = sp_playlist_mock
+def test_get_items_when_playlist_is_malformed(provider, caplog):
+    assert provider.get_items("spotify:user:alice:playlist:malformed") is None
+    assert "No playlist data present" in caplog.text
 
+
+def test_get_items_when_playlist_is_unknown(provider, caplog):
+    assert provider.get_items("spotify:user:alice:playlist:unknown") is None
+    assert (
+        "Failed to lookup Spotify playlist URI "
+        "spotify:user:alice:playlist:unknown" in caplog.text
+    )
+
+
+def test_as_get_items_uses_cache(provider, web_client_mock):
+    provider.get_items("spotify:user:alice:playlist:foo")
+
+    web_client_mock.get_playlist.assert_called_once_with(
+        "spotify:user:alice:playlist:foo", playlists._cache
+    )
+
+
+def test_lookup(provider):
     playlist = provider.lookup("spotify:user:alice:playlist:foo")
 
     assert playlist.uri == "spotify:user:alice:playlist:foo"
@@ -123,115 +129,30 @@ def test_lookup(session_mock, sp_playlist_mock, provider):
     assert playlist.tracks[0].bitrate == 160
 
 
-def test_lookup_loads_playlist_when_a_playlist_isnt_loaded(
-    sp_playlist_mock, session_mock, provider
+def test_lookup_when_playlist_is_empty(provider, caplog):
+    assert provider.lookup("nothing") is None
+    assert "Failed to lookup Spotify playlist URI nothing" in caplog.text
+
+
+def test_lookup_of_playlist_with_other_owner(provider):
+    playlist = provider.lookup("spotify:user:bob:playlist:baz")
+
+    assert playlist.uri == "spotify:user:bob:playlist:baz"
+    assert playlist.name == "Baz (by bob)"
+
+
+def test_lookup_uses_cache(provider, web_client_mock):
+    provider.lookup("spotify:user:alice:playlist:foo")
+
+    web_client_mock.get_playlist.assert_called_once_with(
+        "spotify:user:alice:playlist:foo", playlists._cache
+    )
+
+
+def test_on_playlists_loaded_triggers_playlists_loaded_event(
+    caplog, backend_listener_mock
 ):
-    is_loaded_mock = mock.PropertyMock()
-    type(sp_playlist_mock).is_loaded = is_loaded_mock
-    is_loaded_mock.side_effect = [False, True]
-    session_mock.get_playlist.return_value = sp_playlist_mock
+    playlists.on_playlists_loaded()
 
-    playlist = provider.lookup("spotify:user:alice:playlist:foo")
-
-    sp_playlist_mock.load.assert_called_once_with(10)
-    assert playlist.uri == "spotify:user:alice:playlist:foo"
-    assert playlist.name == "Foo"
-
-
-def test_lookup_when_playlist_is_unknown(session_mock, provider):
-    session_mock.get_playlist.side_effect = spotify.Error
-
-    assert provider.lookup("foo") is None
-
-
-def test_lookup_of_playlist_with_other_owner(
-    session_mock, sp_user_mock, sp_playlist_mock, provider
-):
-    sp_user_mock.canonical_name = "bob"
-    sp_playlist_mock.owner = sp_user_mock
-    session_mock.get_playlist.return_value = sp_playlist_mock
-
-    playlist = provider.lookup("spotify:user:alice:playlist:foo")
-
-    assert playlist.uri == "spotify:user:alice:playlist:foo"
-    assert playlist.name == "Foo (by bob)"
-
-
-def test_create(session_mock, sp_playlist_mock, provider):
-    session_mock.playlist_container = mock.Mock(spec=spotify.PlaylistContainer)
-    session_mock.playlist_container.add_new_playlist.return_value = (
-        sp_playlist_mock
-    )
-
-    playlist = provider.create("Foo")
-
-    session_mock.playlist_container.add_new_playlist.assert_called_once_with(
-        "Foo"
-    )
-    assert playlist.uri == "spotify:user:alice:playlist:foo"
-    assert playlist.name == "Foo"
-
-
-def test_create_with_invalid_name(session_mock, provider, caplog):
-    session_mock.playlist_container = mock.Mock(spec=spotify.PlaylistContainer)
-    session_mock.playlist_container.add_new_playlist.side_effect = ValueError(
-        "Too long name"
-    )
-
-    playlist = provider.create("Foo")
-
-    assert playlist is None
-    assert (
-        'Failed creating new Spotify playlist "Foo": Too long name'
-        in caplog.text
-    )
-
-
-def test_create_fails_in_libspotify(session_mock, provider, caplog):
-    session_mock.playlist_container = mock.Mock(spec=spotify.PlaylistContainer)
-    session_mock.playlist_container.add_new_playlist.side_effect = spotify.Error
-
-    playlist = provider.create("Foo")
-
-    assert playlist is None
-    assert 'Failed creating new Spotify playlist "Foo"' in caplog.text
-
-
-def test_on_container_loaded_triggers_playlists_loaded_event(
-    sp_playlist_container_mock, caplog, backend_listener_mock
-):
-    playlists.on_container_loaded(sp_playlist_container_mock)
-
-    assert "Spotify playlist container loaded" in caplog.text
+    assert "Spotify playlists loaded" in caplog.text
     backend_listener_mock.send.assert_called_once_with("playlists_loaded")
-
-
-def test_on_playlist_added_does_nothing_yet(
-    sp_playlist_container_mock, sp_playlist_mock, caplog, backend_listener_mock
-):
-    playlists.on_playlist_added(sp_playlist_container_mock, sp_playlist_mock, 0)
-
-    assert 'Spotify playlist "Foo" added to index 0' in caplog.text
-    assert backend_listener_mock.send.call_count == 0
-
-
-def test_on_playlist_removed_does_nothing_yet(
-    sp_playlist_container_mock, sp_playlist_mock, caplog, backend_listener_mock
-):
-    playlists.on_playlist_removed(
-        sp_playlist_container_mock, sp_playlist_mock, 0
-    )
-
-    assert 'Spotify playlist "Foo" removed from index 0' in caplog.text
-    assert backend_listener_mock.send.call_count == 0
-
-
-def test_on_playlist_moved_does_nothing_yet(
-    sp_playlist_container_mock, sp_playlist_mock, caplog, backend_listener_mock
-):
-    playlists.on_playlist_moved(
-        sp_playlist_container_mock, sp_playlist_mock, 0, 1
-    )
-
-    assert 'Spotify playlist "Foo" moved from index 0 to 1' in caplog.text
-    assert backend_listener_mock.send.call_count == 0

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -118,7 +118,7 @@ def test_get_items_when_offline(web_client_mock, provider, caplog):
     assert provider.get_items("spotify:user:alice:playlist:foo") is None
     assert (
         "Failed to lookup Spotify playlist URI "
-        "spotify:user:alice:playlist:foo" in caplog.text
+        "'spotify:user:alice:playlist:foo'" in caplog.text
     )
 
 
@@ -139,7 +139,7 @@ def test_get_items_when_playlist_is_unknown(provider, caplog):
     assert provider.get_items("spotify:user:alice:playlist:unknown") is None
     assert (
         "Failed to lookup Spotify playlist URI "
-        "spotify:user:alice:playlist:unknown" in caplog.text
+        "'spotify:user:alice:playlist:unknown'" in caplog.text
     )
 
 
@@ -179,7 +179,7 @@ def test_refresh_sets_loaded(provider, web_client_mock):
 def test_refresh_counts_playlists(provider, caplog):
     provider.refresh()
 
-    assert "Refreshed 2 playlists" in caplog.text
+    assert "Refreshed 2 Spotify playlists" in caplog.text
 
 
 def test_refresh_clears_caches(provider, web_client_mock):
@@ -218,7 +218,7 @@ def test_lookup_when_not_loaded(provider):
 
 def test_lookup_when_playlist_is_empty(provider, caplog):
     assert provider.lookup("nothing") is None
-    assert "Failed to lookup Spotify playlist URI nothing" in caplog.text
+    assert "Failed to lookup Spotify playlist URI 'nothing'" in caplog.text
 
 
 def test_lookup_of_playlist_with_other_owner(provider):
@@ -289,7 +289,7 @@ def test_playlist_lookup_when_playlist_is_empty(
     )
 
     assert playlist is None
-    assert "Failed to lookup Spotify playlist URI nothing" in caplog.text
+    assert "Failed to lookup Spotify playlist URI 'nothing'" in caplog.text
     assert len(playlists._sp_links) == 0
 
 
@@ -305,7 +305,7 @@ def test_playlist_lookup_when_link_invalid(
     )
 
     assert len(playlist.tracks) == 1
-    assert 'Failed to get link "spotify:track:abc"' in caplog.text
+    assert "Failed to get link 'spotify:track:abc'" in caplog.text
 
 
 def test_on_playlists_loaded_triggers_playlists_loaded_event(

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+import spotify
 from mopidy import backend as backend_api
 from mopidy.models import Ref
 
@@ -43,6 +44,8 @@ def web_client_mock(web_client_mock, web_track_mock):
 @pytest.fixture
 def provider(backend_mock, web_client_mock):
     backend_mock._web_client = web_client_mock
+    playlists._cache.clear()
+    playlists._sp_links.clear()
     provider = playlists.SpotifyPlaylistsProvider(backend_mock)
     provider._loaded = True
     return provider
@@ -169,6 +172,15 @@ def test_refresh_clears_web_cache(provider):
     assert len(playlists._cache) == 0
 
 
+def test_refresh_clears_link_cache(provider):
+    playlists._sp_links = {"bar": "foobar", "bar2": "foofoo"}
+
+    provider.refresh()
+
+    assert len(playlists._sp_links) == 1
+    assert list(playlists._sp_links.keys()) == ["spotify:track:abc"]
+
+
 def test_lookup(provider):
     playlist = provider.lookup("spotify:user:alice:playlist:foo")
 
@@ -198,8 +210,90 @@ def test_lookup_of_playlist_with_other_owner(provider):
     assert playlist.name == "Baz (by bob)"
 
 
-def test_lookup_uses_cache(provider, web_client_mock):
-    provider.lookup("spotify:user:alice:playlist:foo")
+@pytest.mark.parametrize("as_items", [(False), (True)])
+def test_playlist_lookup_stores_track_link(
+    session_mock,
+    web_client_mock,
+    sp_track_mock,
+    web_playlist_mock,
+    web_track_mock,
+    as_items,
+):
+    session_mock.get_link.return_value = sp_track_mock.link
+    web_playlist_mock["tracks"]["items"] = [{"track": web_track_mock}] * 5
+    web_client_mock.get_playlist.return_value = web_playlist_mock
+    playlists._sp_links.clear()
+
+    playlists.playlist_lookup(
+        session_mock,
+        web_client_mock,
+        "spotify:user:alice:playlist:foo",
+        None,
+        as_items,
+    )
+
+    session_mock.get_link.assert_called_once_with("spotify:track:abc")
+    assert len(playlists._sp_links) == 1
+
+
+@pytest.mark.parametrize(
+    "connection_state",
+    [
+        (spotify.ConnectionState.OFFLINE),
+        (spotify.ConnectionState.DISCONNECTED),
+        (spotify.ConnectionState.LOGGED_OUT),
+    ],
+)
+def test_playlist_lookup_when_not_logged_in(
+    session_mock, web_client_mock, web_playlist_mock, connection_state
+):
+    web_client_mock.get_playlist.return_value = web_playlist_mock
+    session_mock.connection.state = connection_state
+    playlists._sp_links.clear()
+
+    playlist = playlists.playlist_lookup(
+        session_mock, web_client_mock, "spotify:user:alice:playlist:foo", None
+    )
+
+    assert playlist.uri == "spotify:user:alice:playlist:foo"
+    assert playlist.name == "Foo"
+    assert len(playlists._sp_links) == 0
+
+
+def test_playlist_lookup_when_playlist_is_empty(
+    session_mock, web_client_mock, caplog
+):
+    web_client_mock.get_playlist.return_value = {}
+    playlists._sp_links.clear()
+
+    playlist = playlists.playlist_lookup(
+        session_mock, web_client_mock, "nothing", None
+    )
+
+    assert playlist is None
+    assert "Failed to lookup Spotify playlist URI nothing" in caplog.text
+    assert len(playlists._sp_links) == 0
+
+
+def test_playlist_lookup_when_link_invalid(
+    session_mock, web_client_mock, web_playlist_mock, caplog
+):
+    session_mock.get_link.side_effect = ValueError("an error message")
+    web_client_mock.get_playlist.return_value = web_playlist_mock
+    playlists._sp_links.clear()
+
+    playlist = playlists.playlist_lookup(
+        session_mock, web_client_mock, "spotify:user:alice:playlist:foo", None
+    )
+
+    assert len(playlist.tracks) == 1
+    assert 'Failed to get link "spotify:track:abc"' in caplog.text
+
+
+def test_playlist_lookup_uses_cache(session_mock, web_client_mock):
+    playlists.playlist_lookup(
+        session_mock, web_client_mock, "spotify:user:alice:playlist:foo", None
+    )
 
     web_client_mock.get_playlist.assert_called_once_with(
         "spotify:user:alice:playlist:foo", playlists._cache

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -55,7 +55,7 @@ def test_is_a_playlists_provider(provider):
 
 
 def test_as_list_when_not_logged_in(web_client_mock, provider):
-    web_client_mock.user_id = None
+    web_client_mock.logged_in = False
 
     result = provider.as_list()
 
@@ -70,7 +70,7 @@ def test_as_list_when_offline(web_client_mock, provider):
     assert len(result) == 0
 
 
-def test_as_list_blocked_when_not_loaded(provider):
+def test_as_list_when_not_loaded(provider):
     provider._loaded = False
 
     result = provider.as_list()
@@ -78,7 +78,7 @@ def test_as_list_blocked_when_not_loaded(provider):
     assert len(result) == 0
 
 
-def test_as_list_when_playlist_wont_translate(provider, caplog):
+def test_as_list_when_playlist_wont_translate(provider):
     result = provider.as_list()
 
     assert len(result) == 2
@@ -104,20 +104,34 @@ def test_get_items_when_playlist_without_tracks(provider):
 
     assert len(result) == 0
 
-    assert result == []
+
+def test_get_items_when_not_logged_in(web_client_mock, provider):
+    web_client_mock.logged_in = False
+
+    assert provider.get_items("spotify:user:alice:playlist:foo") is None
 
 
-def test_get_items_blocked_when_not_loaded(provider):
+def test_get_items_when_offline(web_client_mock, provider, caplog):
+    web_client_mock.get_playlist.side_effect = None
+    web_client_mock.get_playlist.return_value = {}
+
+    assert provider.get_items("spotify:user:alice:playlist:foo") is None
+    assert (
+        "Failed to lookup Spotify playlist URI "
+        "spotify:user:alice:playlist:foo" in caplog.text
+    )
+
+
+def test_get_items_when_not_loaded(provider):
     provider._loaded = False
 
     result = provider.get_items("spotify:user:alice:playlist:foo")
 
-    assert len(result) == 0
+    assert len(result) == 1
+    assert result[0] == Ref.track(uri="spotify:track:abc", name="ABC 123")
 
-    assert result == []
 
-
-def test_get_items_when_playlist_wont_translate(provider, caplog):
+def test_get_items_when_playlist_wont_translate(provider):
     assert provider.get_items("spotify:user:alice:playlist:malformed") is None
 
 
@@ -141,7 +155,18 @@ def test_refresh_loads_all_playlists(provider, web_client_mock):
     web_client_mock.get_playlist.assert_has_calls(expected_calls)
 
 
-def test_refresh_when_not_loaded(provider, web_client_mock):
+def test_refresh_when_not_logged_in(provider, web_client_mock):
+    provider._loaded = False
+    web_client_mock.logged_in = False
+
+    provider.refresh()
+
+    web_client_mock.get_user_playlists.assert_not_called()
+    web_client_mock.get_playlist.assert_not_called()
+    assert not provider._loaded
+
+
+def test_refresh_sets_loaded(provider, web_client_mock):
     provider._loaded = False
 
     provider.refresh()
@@ -157,13 +182,13 @@ def test_refresh_counts_playlists(provider, caplog):
     assert "Refreshed 2 playlists" in caplog.text
 
 
-def test_refresh_clears_link_cache(provider):
-    playlists._sp_links = {"bar": "foobar", "bar2": "foofoo"}
+def test_refresh_clears_caches(provider, web_client_mock):
+    playlists._sp_links = {"bar": "foobar"}
 
     provider.refresh()
 
-    assert len(playlists._sp_links) == 1
-    assert list(playlists._sp_links.keys()) == ["spotify:track:abc"]
+    assert "bar" not in playlists._sp_links
+    web_client_mock.clear_cache.assert_called_once()
 
 
 def test_lookup(provider):
@@ -172,6 +197,14 @@ def test_lookup(provider):
     assert playlist.uri == "spotify:user:alice:playlist:foo"
     assert playlist.name == "Foo"
     assert playlist.tracks[0].bitrate == 160
+
+
+def test_lookup_when_not_logged_in(web_client_mock, provider):
+    web_client_mock.logged_in = False
+
+    playlist = provider.lookup("spotify:user:alice:playlist:foo")
+
+    assert playlist is None
 
 
 def test_lookup_when_not_loaded(provider):
@@ -218,7 +251,7 @@ def test_playlist_lookup_stores_track_link(
     )
 
     session_mock.get_link.assert_called_once_with("spotify:track:abc")
-    assert len(playlists._sp_links) == 1
+    assert {"spotify:track:abc": sp_track_mock.link} == playlists._sp_links
 
 
 @pytest.mark.parametrize(

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -306,12 +306,3 @@ def test_playlist_lookup_when_link_invalid(
 
     assert len(playlist.tracks) == 1
     assert "Failed to get link 'spotify:track:abc'" in caplog.text
-
-
-def test_on_playlists_loaded_triggers_playlists_loaded_event(
-    caplog, backend_listener_mock
-):
-    playlists.on_playlists_loaded()
-
-    assert "Spotify playlists loaded" in caplog.text
-    backend_listener_mock.send.assert_called_once_with("playlists_loaded")

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -1,10 +1,10 @@
 from unittest import mock
 
 import pytest
-import spotify
 from mopidy import backend as backend_api
 from mopidy.models import Ref
 
+import spotify
 from mopidy_spotify import playlists
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,6 @@
-import spotify
-
 from mopidy import models
+
+import spotify
 from mopidy_spotify import search
 
 
@@ -75,7 +75,7 @@ def test_search_returns_albums_and_artists_and_tracks(
         params={
             "q": '"ABBA"',
             "limit": 50,
-            "market": "GB",
+            "market": "from_token",
             "type": "album,artist,track",
         },
     )
@@ -127,7 +127,7 @@ def test_sets_api_limit_to_album_count_when_max(
         params={
             "q": '"ABBA"',
             "limit": 6,
-            "market": "GB",
+            "market": "from_token",
             "type": "album,artist,track",
         },
     )
@@ -151,7 +151,7 @@ def test_sets_api_limit_to_artist_count_when_max(
         params={
             "q": '"ABBA"',
             "limit": 6,
-            "market": "GB",
+            "market": "from_token",
             "type": "album,artist,track",
         },
     )
@@ -175,7 +175,7 @@ def test_sets_api_limit_to_track_count_when_max(
         params={
             "q": '"ABBA"',
             "limit": 6,
-            "market": "GB",
+            "market": "from_token",
             "type": "album,artist,track",
         },
     )
@@ -201,16 +201,15 @@ def test_sets_types_parameter(
         params={
             "q": '"ABBA"',
             "limit": 50,
-            "market": "GB",
+            "market": "from_token",
             "type": "album,artist",
         },
     )
 
 
-def test_sets_market_parameter_from_user_country(
+def test_sets_market_parameter(
     web_client_mock, web_search_mock_large, provider
 ):
-    web_client_mock.user_country = "SE"
     web_client_mock.get.return_value = web_search_mock_large
 
     provider.search({"any": ["ABBA"]})
@@ -220,7 +219,7 @@ def test_sets_market_parameter_from_user_country(
         params={
             "q": '"ABBA"',
             "limit": 50,
-            "market": "SE",
+            "market": "from_token",
             "type": "album,artist,track",
         },
     )

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -208,9 +208,9 @@ def test_sets_types_parameter(
 
 
 def test_sets_market_parameter_from_user_country(
-    web_client_mock, web_search_mock_large, provider, session_mock
+    web_client_mock, web_search_mock_large, provider
 ):
-    session_mock.user_country = "SE"
+    web_client_mock.user_country = "SE"
     web_client_mock.get.return_value = web_search_mock_large
 
     provider.search({"any": ["ABBA"]})

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -239,6 +239,22 @@ class TestToTrackRef:
         assert ref1 is ref2
 
 
+class TestValidWebData(object):
+    def test_returns_none_if_missing_type(self, web_track_mock):
+        del web_track_mock["type"]
+        assert translator.valid_web_data(web_track_mock, "track") is False
+
+    def test_returns_none_if_wrong_type(self, web_track_mock):
+        assert translator.valid_web_data(web_track_mock, "playlist") is False
+
+    def test_returns_none_if_missing_uri(self, web_track_mock):
+        del web_track_mock["uri"]
+        assert translator.valid_web_data(web_track_mock, "track") is False
+
+    def test_returns_success(self, web_track_mock):
+        assert translator.valid_web_data(web_track_mock, "track") is True
+
+
 class TestWebToTrackRef:
     def test_returns_none_if_unloaded(self):
         web_track_mock = {}
@@ -254,12 +270,34 @@ class TestWebToTrackRef:
 
         assert ref is None
 
+    def test_returns_none_if_missing_uri(self, web_track_mock):
+        del web_track_mock["uri"]
+
+        ref = translator.web_to_track_ref(web_track_mock)
+
+        assert ref is None
+
+    def test_returns_none_if_not_playable(self, web_track_mock, caplog):
+        web_track_mock["is_playable"] = False
+
+        ref = translator.web_to_track_ref(web_track_mock)
+
+        assert ref is None
+        assert "spotify:track:abc is not playable" in caplog.text
+
     def test_successful_translation(self, web_track_mock):
         ref = translator.web_to_track_ref(web_track_mock)
 
         assert ref.type == models.Ref.TRACK
         assert ref.uri == "spotify:track:abc"
         assert ref.name == "ABC 123"
+
+    def test_uri_uses_relinked_from_uri(self, web_track_mock):
+        web_track_mock["linked_from"] = {"uri": "spotify:track:xyz"}
+
+        ref = translator.web_to_track_ref(web_track_mock)
+
+        assert ref.uri == "spotify:track:xyz"
 
 
 class TestToPlaylist:

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -154,7 +154,7 @@ class TestToTrack:
 
         assert track is None
         assert (
-            "Error loading spotify:track:abc: <ErrorType.OTHER_PERMANENT: 10>"
+            "Error loading 'spotify:track:abc': <ErrorType.OTHER_PERMANENT: 10>"
             in caplog.text
         )
 
@@ -214,7 +214,7 @@ class TestToTrackRef:
 
         assert ref is None
         assert (
-            "Error loading spotify:track:abc: <ErrorType.OTHER_PERMANENT: 10>"
+            "Error loading 'spotify:track:abc': <ErrorType.OTHER_PERMANENT: 10>"
             in caplog.text
         )
 
@@ -283,7 +283,7 @@ class TestWebToTrackRef:
         ref = translator.web_to_track_ref(web_track_mock)
 
         assert ref is None
-        assert "spotify:track:abc is not playable" in caplog.text
+        assert "'spotify:track:abc' is not playable" in caplog.text
 
     def test_successful_translation(self, web_track_mock):
         ref = translator.web_to_track_ref(web_track_mock)

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,8 +1,6 @@
-from unittest import mock
+from mopidy import models
 
 import spotify
-
-from mopidy import models
 from mopidy_spotify import translator
 
 
@@ -241,25 +239,47 @@ class TestToTrackRef:
         assert ref1 is ref2
 
 
+class TestWebToTrackRef:
+    def test_returns_none_if_unloaded(self):
+        web_track_mock = {}
+
+        ref = translator.web_to_track_ref(web_track_mock)
+
+        assert ref is None
+
+    def test_returns_none_if_wrong_type(self, web_track_mock):
+        web_track_mock["type"] = "playlist"
+
+        ref = translator.web_to_track_ref(web_track_mock)
+
+        assert ref is None
+
+    def test_successful_translation(self, web_track_mock):
+        ref = translator.web_to_track_ref(web_track_mock)
+
+        assert ref.type == models.Ref.TRACK
+        assert ref.uri == "spotify:track:abc"
+        assert ref.name == "ABC 123"
+
+
 class TestToPlaylist:
     def test_returns_none_if_unloaded(self):
-        sp_playlist = mock.Mock(spec=spotify.Playlist)
-        sp_playlist.is_loaded = False
+        web_playlist = {}
 
-        playlist = translator.to_playlist(sp_playlist)
-
-        assert playlist is None
-
-    def test_returns_none_if_playlist_folder(self):
-        sp_playlist_folder = mock.Mock(spec=spotify.PlaylistFolder)
-
-        playlist = translator.to_playlist(sp_playlist_folder)
+        playlist = translator.to_playlist(web_playlist)
 
         assert playlist is None
 
-    def test_successful_translation(self, sp_track_mock, sp_playlist_mock):
-        track = translator.to_track(sp_track_mock)
-        playlist = translator.to_playlist(sp_playlist_mock)
+    def test_returns_none_if_wrong_type(self, web_playlist_mock):
+        web_playlist_mock["type"] = "track"
+
+        playlist = translator.to_playlist(web_playlist_mock)
+
+        assert playlist is None
+
+    def test_successful_translation(self, web_track_mock, web_playlist_mock):
+        track = translator.web_to_track(web_track_mock)
+        playlist = translator.to_playlist(web_playlist_mock)
 
         assert playlist.uri == "spotify:user:alice:playlist:foo"
         assert playlist.name == "Foo"
@@ -267,45 +287,41 @@ class TestToPlaylist:
         assert track in playlist.tracks
         assert playlist.last_modified is None
 
-    def test_as_items(self, sp_track_mock, sp_playlist_mock):
-        track_ref = translator.to_track_ref(sp_track_mock)
-        items = translator.to_playlist(sp_playlist_mock, as_items=True)
+    def test_no_track_data(self, web_playlist_mock):
+        del web_playlist_mock["tracks"]
+
+        playlist = translator.to_playlist(web_playlist_mock)
+
+        assert playlist.uri == "spotify:user:alice:playlist:foo"
+        assert playlist.name == "Foo"
+        assert playlist.length == 0
+
+    def test_as_items(self, web_track_mock, web_playlist_mock):
+        track_ref = translator.web_to_track_ref(web_track_mock)
+        items = translator.to_playlist(web_playlist_mock, as_items=True)
 
         assert track_ref in items
 
-    def test_adds_name_for_starred_playlists(self, sp_starred_mock):
-        playlist = translator.to_playlist(sp_starred_mock)
+    def test_as_items_no_track_data(self, web_playlist_mock):
+        del web_playlist_mock["tracks"]
 
-        assert playlist.name == "Starred"
+        items = translator.to_playlist(web_playlist_mock, as_items=True)
 
-    def test_reorders_starred_playlists(self, sp_starred_mock):
-        playlist = translator.to_playlist(sp_starred_mock)
-
-        assert len(playlist.tracks) == 2
-        assert playlist.tracks[0].name == "Newest"
-        assert playlist.tracks[1].name == "Oldest"
+        assert len(items) == 0
 
     def test_includes_by_owner_in_name_if_owned_by_another_user(
-        self, sp_playlist_mock, sp_user_mock
+        self, web_playlist_mock
     ):
-        sp_user_mock.canonical_name = "bob"
-        sp_playlist_mock.user = sp_user_mock
+        web_playlist_mock["owner"]["id"] = "bob"
 
-        playlist = translator.to_playlist(sp_playlist_mock, username="alice")
+        playlist = translator.to_playlist(web_playlist_mock, username="alice")
 
         assert playlist.name == "Foo (by bob)"
 
-    def test_includes_folders_in_name(self, sp_playlist_mock):
-        playlist = translator.to_playlist(
-            sp_playlist_mock, folders=["Bar", "Baz"]
-        )
+    def test_filters_out_none_tracks(self, web_track_mock, web_playlist_mock):
+        del web_track_mock["type"]
 
-        assert playlist.name == "Bar/Baz/Foo"
-
-    def test_filters_out_none_tracks(self, sp_track_mock, sp_playlist_mock):
-        sp_track_mock.is_loaded = False
-
-        playlist = translator.to_playlist(sp_playlist_mock)
+        playlist = translator.to_playlist(web_playlist_mock)
 
         assert playlist.length == 0
         assert list(playlist.tracks) == []
@@ -313,47 +329,41 @@ class TestToPlaylist:
 
 class TestToPlaylistRef:
     def test_returns_none_if_unloaded(self):
-        sp_playlist = mock.Mock(spec=spotify.Playlist)
-        sp_playlist.is_loaded = False
+        web_playlist = {}
 
-        ref = translator.to_playlist_ref(sp_playlist)
-
-        assert ref is None
-
-    def test_returns_none_if_playlist_folder(self):
-        sp_playlist_folder = mock.Mock(spec=spotify.PlaylistFolder)
-
-        ref = translator.to_playlist_ref(sp_playlist_folder)
+        ref = translator.to_playlist_ref(web_playlist)
 
         assert ref is None
 
-    def test_successful_translation(self, sp_track_mock, sp_playlist_mock):
-        ref = translator.to_playlist_ref(sp_playlist_mock)
+    def test_returns_none_if_wrong_type(self, web_playlist_mock):
+        web_playlist_mock["type"] = "track"
+
+        ref = translator.to_playlist_ref(web_playlist_mock)
+
+        assert ref is None
+
+    def test_successful_translation(self, web_playlist_mock):
+        ref = translator.to_playlist_ref(web_playlist_mock)
 
         assert ref.uri == "spotify:user:alice:playlist:foo"
         assert ref.name == "Foo"
 
-    def test_adds_name_for_starred_playlists(self, sp_starred_mock):
-        ref = translator.to_playlist_ref(sp_starred_mock)
+    def test_success_without_track_data(self, web_playlist_mock):
+        del web_playlist_mock["tracks"]
 
-        assert ref.name == "Starred"
+        ref = translator.to_playlist_ref(web_playlist_mock)
+
+        assert ref.uri == "spotify:user:alice:playlist:foo"
+        assert ref.name == "Foo"
 
     def test_includes_by_owner_in_name_if_owned_by_another_user(
-        self, sp_playlist_mock, sp_user_mock
+        self, web_playlist_mock
     ):
-        sp_user_mock.canonical_name = "bob"
-        sp_playlist_mock.user = sp_user_mock
+        web_playlist_mock["owner"]["id"] = "bob"
 
-        ref = translator.to_playlist_ref(sp_playlist_mock, username="alice")
+        ref = translator.to_playlist_ref(web_playlist_mock, username="alice")
 
         assert ref.name == "Foo (by bob)"
-
-    def test_includes_folders_in_name(self, sp_playlist_mock):
-        ref = translator.to_playlist_ref(
-            sp_playlist_mock, folders=["Bar", "Baz"]
-        )
-
-        assert ref.name == "Bar/Baz/Foo"
 
 
 class TestSpotifySearchQuery:
@@ -463,3 +473,26 @@ class TestWebToTrack:
         assert track.track_no == 7
         assert track.disc_no == 1
         assert track.length == 174300
+
+    def test_sets_bitrate(self, web_track_mock):
+        track = translator.web_to_track(web_track_mock, bitrate=100)
+
+        assert track.bitrate == 100
+
+    def test_filters_out_none_artists(self, web_track_mock):
+        web_track_mock["artists"].insert(0, {})
+        web_track_mock["artists"].insert(0, {"foo": "bar"})
+
+        track = translator.web_to_track(web_track_mock)
+        artists = [models.Artist(uri="spotify:artist:abba", name="ABBA")]
+
+        assert list(track.artists) == artists
+
+    def test_ignores_missing_album(self, web_track_mock):
+        del web_track_mock["album"]
+
+        track = translator.web_to_track(web_track_mock)
+
+        assert track.name == "ABC 123"
+        assert track.length == 174300
+        assert track.album is None

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -679,7 +679,9 @@ def test_updated_responses_changed(web_response_mock, oauth_client, mock_time):
 @pytest.fixture
 def spotify_client(config):
     return web.SpotifyOAuthClient(
-        config["spotify"]["client_id"], config["spotify"]["client_secret"], None
+        client_id=config["spotify"]["client_id"],
+        client_secret=config["spotify"]["client_secret"],
+        proxy_config=None,
     )
 
 
@@ -720,7 +722,9 @@ class TestSpotifyOAuthClient:
         assert field in web.SpotifyOAuthClient.PLAYLIST_FIELDS
 
     def test_configures_auth(self):
-        client = web.SpotifyOAuthClient("1234567", "AbCdEfG", None)
+        client = web.SpotifyOAuthClient(
+            client_id="1234567", client_secret="AbCdEfG", proxy_config=None
+        )
 
         assert client._auth == ("1234567", "AbCdEfG")
 
@@ -732,7 +736,9 @@ class TestSpotifyOAuthClient:
             "username": "alice",
             "password": "s3cret",
         }
-        client = web.SpotifyOAuthClient(None, None, proxy_config)
+        client = web.SpotifyOAuthClient(
+            client_id=None, client_secret=None, proxy_config=proxy_config
+        )
 
         assert (
             client._session.proxies["https"]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -994,14 +994,14 @@ class TestSpotifyOAuthClient:
 @pytest.mark.parametrize(
     "uri,type_,id_",
     [
-        ("spotify:playlist:foo", "playlist", "foo"),
-        ("spotify:track:bar", "track", "bar"),
-        ("spotify:artist:blah", "artist", "blah"),
-        ("spotify:album:stuff", "album", "stuff"),
+        ("spotify:playlist:foo", web.LinkType.PLAYLIST, "foo"),
+        ("spotify:track:bar", web.LinkType.TRACK, "bar"),
+        ("spotify:artist:blah", web.LinkType.ARTIST, "blah"),
+        ("spotify:album:stuff", web.LinkType.ALBUM, "stuff"),
     ],
 )
-def test_parse_uri_spotify_uri(uri, type_, id_):
-    result = web.parse_uri(uri)
+def test_weblink_from_uri_spotify_uri(uri, type_, id_):
+    result = web.WebLink.from_uri(uri)
 
     assert result.uri == uri
     assert result.type == type_
@@ -1019,11 +1019,11 @@ def test_parse_uri_spotify_uri(uri, type_, id_):
         ("https://play.spotify.com/playlist/foo", "foo", None),
     ],
 )
-def test_parse_uri_playlist(uri, id_, owner):
-    result = web.parse_uri(uri)
+def test_weblink_from_uri_playlist(uri, id_, owner):
+    result = web.WebLink.from_uri(uri)
 
     assert result.uri == uri
-    assert result.type == "playlist"
+    assert result.type == web.LinkType.PLAYLIST
     assert result.id == id_
     assert result.owner == owner
 
@@ -1040,9 +1040,9 @@ def test_parse_uri_playlist(uri, id_, owner):
         ("total/junk"),
     ],
 )
-def test_parse_uri_raises(uri):
+def test_weblink_from_uri_raises(uri):
     with pytest.raises(ValueError) as excinfo:
-        result = web.parse_uri(uri)
+        result = web.WebLink.from_uri(uri)
         assert result is None
 
-    assert f"Could not parse {repr(uri)} as a Spotify URI" in str(excinfo.value)
+    assert f"Could not parse {uri!r} as a Spotify URI" in str(excinfo.value)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,3 +1,4 @@
+import urllib
 from unittest import mock
 
 import pytest
@@ -563,3 +564,356 @@ def test_cache_miss_no_etag(web_response_mock_etag, oauth_client, mock_time):
     assert "If-None-Match" not in responses.calls[0].request.headers
     assert result["uri"] == "spotify:track:xyz"
     assert cache["tracks/xyz"] == result
+
+
+@pytest.fixture
+def spotify_client(config):
+    return web.SpotifyOAuthClient(
+        config["spotify"]["client_id"], config["spotify"]["client_secret"], None
+    )
+
+
+@pytest.yield_fixture(scope="class")
+def skip_refresh_token():
+    patcher = mock.patch.object(web.OAuthClient, "_should_refresh_token")
+    mock_refresh = patcher.start()
+    mock_refresh.return_value = False
+    yield mock_refresh
+    patcher.stop()
+
+
+@pytest.mark.usefixtures("skip_refresh_token")
+class TestSpotifyOAuthClient:
+    def url(self, endpoint):
+        return f"https://api.spotify.com/v1/{endpoint}"
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            ("next"),
+            ("items(track"),
+            ("type"),
+            ("uri"),
+            ("name"),
+            ("is_playable"),
+            ("linked_from"),
+        ],
+    )
+    def test_track_required_fields(self, field, spotify_client):
+        assert field in spotify_client.TRACK_FIELDS
+
+    @pytest.mark.parametrize(
+        "field",
+        [("name"), ("type"), ("uri"), ("name"), ("snapshot_id"), ("tracks")],
+    )
+    def test_playlist_required_fields(self, field, spotify_client):
+        assert field in spotify_client.PLAYLIST_FIELDS
+
+    def test_configures_auth(self):
+        client = web.SpotifyOAuthClient("1234567", "AbCdEfG", None)
+
+        assert client._auth == ("1234567", "AbCdEfG")
+
+    def test_configures_proxy(self):
+        proxy_config = {
+            "scheme": "https",
+            "hostname": "my-proxy.example.com",
+            "port": 8080,
+            "username": "alice",
+            "password": "s3cret",
+        }
+        client = web.SpotifyOAuthClient(None, None, proxy_config)
+
+        assert (
+            client._session.proxies["https"]
+            == "https://alice:s3cret@my-proxy.example.com:8080"
+        )
+
+    def test_configures_urls(self, spotify_client):
+        assert spotify_client._base_url == "https://api.spotify.com/v1"
+        assert (
+            spotify_client._refresh_url
+            == "https://auth.mopidy.com/spotify/token"
+        )
+
+    @responses.activate
+    def test_login_alice(self, spotify_client, caplog):
+        responses.add(responses.GET, self.url("me"), json={"id": "alice"})
+
+        assert spotify_client.login()
+        assert spotify_client.user_id == "alice"
+        assert "Logged into Spotify Web API as alice" in caplog.text
+
+    @responses.activate
+    def test_login_fails(self, spotify_client, caplog):
+        responses.add(responses.GET, self.url("me"), json={})
+
+        assert not spotify_client.login()
+        assert spotify_client.user_id is None
+        assert "Failed to load Spotify user profile" in caplog.text
+
+    @responses.activate
+    def test_get_all(self, spotify_client):
+        responses.add(
+            responses.GET, self.url("page1"), json={"n": 1, "next": "page2"}
+        )
+        responses.add(responses.GET, self.url("page2"), json={"n": 2})
+
+        results = list(spotify_client.get_all("page1"))
+
+        assert len(results) == 2
+        assert results[0].get("n") == 1
+        assert results[1].get("n") == 2
+
+    @responses.activate
+    def test_get_all_none(self, spotify_client):
+        results = list(spotify_client.get_all(None))
+
+        assert len(responses.calls) == 0
+        assert len(results) == 0
+
+    @responses.activate
+    def test_get_user_playlists_empty(self, spotify_client):
+        responses.add(responses.GET, self.url("me/playlists"), json={})
+
+        result = list(spotify_client.get_user_playlists())
+
+        assert len(responses.calls) == 1
+        assert len(result) == 0
+
+    @responses.activate
+    def test_get_user_playlists_sets_params(self, spotify_client):
+        responses.add(responses.GET, self.url("me/playlists"), json={})
+
+        list(spotify_client.get_user_playlists())
+
+        assert len(responses.calls) == 1
+        encoded_params = urllib.parse.urlencode({"limit": 50})
+        assert responses.calls[0].request.url == self.url(
+            f"me/playlists?{encoded_params}"
+        )
+
+    @responses.activate
+    def test_get_user_playlists(self, spotify_client):
+        responses.add(
+            responses.GET,
+            self.url("me/playlists?limit=50"),
+            json={
+                "next": self.url("me/playlists?offset=50"),
+                "items": ["playlist0", "playlist1", "playlist2"],
+            },
+        )
+        responses.add(
+            responses.GET,
+            self.url("me/playlists?limit=50&offset=50"),
+            json={
+                "next": None,
+                "items": ["playlist3", "playlist4", "playlist5"],
+            },
+        )
+
+        results = list(spotify_client.get_user_playlists())
+
+        assert len(responses.calls) == 2
+        assert len(results) == 6
+        assert [f"playlist{i}" for i in range(6)] == results
+
+    @responses.activate
+    def test_get_user_playlists_uses_cache(self, spotify_client, mock_time):
+        web_resp = web.WebResponse(
+            "me/playlists?limit=50", {"items": ["playlist"]}, status_code=200
+        )
+        cache = {web_resp.url: web_resp}
+        mock_time.return_value = -1000
+
+        result = list(spotify_client.get_user_playlists(cache))
+
+        assert len(responses.calls) == 0
+        assert result[0] == "playlist"
+
+    @responses.activate
+    @pytest.mark.parametrize(
+        "uri,success",
+        [
+            ("spotify:user:alice:playlist:foo", True),
+            ("spotify:user:alice:playlist:fake", False),
+            ("spotify:playlist:foo", True),
+            ("spotify:track:foo", False),
+            ("https://play.spotify.com/foo", False),
+            ("total/junk", False),
+        ],
+    )
+    def test_get_playlist(
+        self, spotify_client, web_playlist_mock, uri, success
+    ):
+        responses.add(
+            responses.GET, self.url("playlists/foo"), json=web_playlist_mock
+        )
+        responses.add(responses.GET, self.url("playlists/fake"), json=None)
+
+        result = spotify_client.get_playlist(uri)
+
+        if success:
+            assert result == web_playlist_mock
+        else:
+            assert result == {}
+
+    @responses.activate
+    def test_get_playlist_sets_params_for_playlist(self, spotify_client):
+        responses.add(responses.GET, self.url("playlists/foo"), json={})
+
+        spotify_client.get_playlist("spotify:playlist:foo")
+
+        assert len(responses.calls) == 1
+        encoded_params = urllib.parse.urlencode(
+            {"fields": spotify_client.PLAYLIST_FIELDS, "market": "from_token"}
+        )
+        assert responses.calls[0].request.url == self.url(
+            f"playlists/foo?{encoded_params}"
+        )
+
+    @responses.activate
+    def test_get_playlist_sets_params_for_tracks(self, spotify_client):
+        responses.add(
+            responses.GET,
+            self.url("playlists/foo"),
+            json={"tracks": {"next": "playlists/foo/tracks1"}},
+        )
+        responses.add(
+            responses.GET,
+            self.url("playlists/foo/tracks1"),
+            json={"next": "playlists/foo/tracks2"},
+        )
+        responses.add(responses.GET, self.url("playlists/foo/tracks2"), json={})
+
+        spotify_client.get_playlist("spotify:playlist:foo")
+
+        assert len(responses.calls) == 3
+        encoded_params = urllib.parse.urlencode(
+            {"fields": spotify_client.TRACK_FIELDS, "market": "from_token"}
+        )
+        assert responses.calls[1].request.url == self.url(
+            f"playlists/foo/tracks1?{encoded_params}"
+        )
+        assert responses.calls[2].request.url == self.url(
+            f"playlists/foo/tracks2?{encoded_params}"
+        )
+
+    @responses.activate
+    def test_get_playlist_collates_tracks(self, spotify_client):
+        responses.add(
+            responses.GET,
+            self.url("playlists/foo"),
+            json={"tracks": {"items": [1, 2], "next": "playlists/foo/tracks"}},
+        )
+        responses.add(
+            responses.GET,
+            self.url("playlists/foo/tracks"),
+            json={"items": [3, 4, 5]},
+        )
+
+        result = spotify_client.get_playlist("spotify:playlist:foo")
+
+        assert len(responses.calls) == 2
+        assert result["tracks"]["items"] == [1, 2, 3, 4, 5]
+
+    @responses.activate
+    def test_get_playlist_uses_cache(self, mock_time, spotify_client):
+        responses.add(
+            responses.GET,
+            self.url("playlists/foo"),
+            json={"tracks": {"items": [1, 2], "next": "playlists/foo/tracks"}},
+        )
+        responses.add(
+            responses.GET,
+            self.url("playlists/foo/tracks"),
+            json={"items": [3, 4, 5]},
+        )
+        mock_time.return_value = -1000
+
+        cache = {}
+        result1 = spotify_client.get_playlist("spotify:playlist:foo", cache)
+
+        assert len(responses.calls) == 2
+        assert result1["tracks"]["items"] == [1, 2, 3, 4, 5]
+
+        assert len(cache) == 2
+        base_url = self.url("")
+        url0 = responses.calls[0].request.url[len(base_url) :]
+        assert cache[url0]["tracks"]["items"] == [1, 2]
+        url1 = responses.calls[1].request.url[len(base_url) :]
+        assert cache[url1]["items"] == [3, 4, 5]
+
+        responses.calls.reset()
+        result2 = spotify_client.get_playlist("spotify:playlist:foo", cache)
+
+        assert len(responses.calls) == 0
+        assert result1 == result2
+
+    @pytest.mark.parametrize(
+        "uri,msg",
+        [
+            ("spotify:artist:foo", "Spotify playlist"),
+            ("my-bad-uri", "Spotify"),
+        ],
+    )
+    def test_get_playlist_error_msg(self, spotify_client, caplog, uri, msg):
+        assert spotify_client.get_playlist(uri) == {}
+        assert f"Could not parse {uri!r} as a {msg} URI" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "uri,type_,id_",
+    [
+        ("spotify:playlist:foo", "playlist", "foo"),
+        ("spotify:track:bar", "track", "bar"),
+        ("spotify:artist:blah", "artist", "blah"),
+        ("spotify:album:stuff", "album", "stuff"),
+    ],
+)
+def test_parse_uri_spotify_uri(uri, type_, id_):
+    result = web.parse_uri(uri)
+
+    assert result.uri == uri
+    assert result.type == type_
+    assert result.id == id_
+    assert result.owner is None
+
+
+@pytest.mark.parametrize(
+    "uri,id_,owner",
+    [
+        ("spotify:user:alice:playlist:foo", "foo", "alice"),
+        ("spotify:playlist:foo", "foo", None),
+        ("http://open.spotify.com/playlist/foo", "foo", None),
+        ("https://open.spotify.com/playlist/foo", "foo", None),
+        ("https://play.spotify.com/playlist/foo", "foo", None),
+    ],
+)
+def test_parse_uri_playlist(uri, id_, owner):
+    result = web.parse_uri(uri)
+
+    assert result.uri == uri
+    assert result.type == "playlist"
+    assert result.id == id_
+    assert result.owner == owner
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        ("spotify:user:alice:track:foo"),
+        ("local:user:alice:playlist:foo"),
+        ("spotify:track:foo:bar"),
+        ("spotify:album:"),
+        ("https://yahoo.com/playlist/foo"),
+        ("https://play.spotify.com/foo"),
+        ("total/junk"),
+    ],
+)
+def test_parse_uri_raises(uri):
+    with pytest.raises(ValueError) as excinfo:
+        result = web.parse_uri(uri)
+        assert result is None
+
+    assert f"Could not parse {repr(uri)} as a Spotify URI" in str(excinfo.value)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -723,10 +723,10 @@ class TestSpotifyOAuthClient:
         web_resp = web.WebResponse(
             "me/playlists?limit=50", {"items": ["playlist"]}, status_code=200
         )
-        cache = {web_resp.url: web_resp}
+        spotify_client._cache = {web_resp.url: web_resp}
         mock_time.return_value = -1000
 
-        result = list(spotify_client.get_user_playlists(cache))
+        result = list(spotify_client.get_user_playlists())
 
         assert len(responses.calls) == 0
         assert result[0] == "playlist"
@@ -831,21 +831,20 @@ class TestSpotifyOAuthClient:
         )
         mock_time.return_value = -1000
 
-        cache = {}
-        result1 = spotify_client.get_playlist("spotify:playlist:foo", cache)
+        result1 = spotify_client.get_playlist("spotify:playlist:foo")
 
         assert len(responses.calls) == 2
         assert result1["tracks"]["items"] == [1, 2, 3, 4, 5]
 
-        assert len(cache) == 2
+        assert len(spotify_client._cache) == 2
         base_url = self.url("")
         url0 = responses.calls[0].request.url[len(base_url) :]
-        assert cache[url0]["tracks"]["items"] == [1, 2]
+        assert spotify_client._cache[url0]["tracks"]["items"] == [1, 2]
         url1 = responses.calls[1].request.url[len(base_url) :]
-        assert cache[url1]["items"] == [3, 4, 5]
+        assert spotify_client._cache[url1]["items"] == [3, 4, 5]
 
         responses.calls.reset()
-        result2 = spotify_client.get_playlist("spotify:playlist:foo", cache)
+        result2 = spotify_client.get_playlist("spotify:playlist:foo")
 
         assert len(responses.calls) == 0
         assert result1 == result2

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -599,15 +599,15 @@ class TestSpotifyOAuthClient:
             ("linked_from"),
         ],
     )
-    def test_track_required_fields(self, field, spotify_client):
-        assert field in spotify_client.TRACK_FIELDS
+    def test_track_required_fields(self, field):
+        assert field in web.SpotifyOAuthClient.TRACK_FIELDS
 
     @pytest.mark.parametrize(
         "field",
         [("name"), ("type"), ("uri"), ("name"), ("snapshot_id"), ("tracks")],
     )
-    def test_playlist_required_fields(self, field, spotify_client):
-        assert field in spotify_client.PLAYLIST_FIELDS
+    def test_playlist_required_fields(self, field):
+        assert field in web.SpotifyOAuthClient.PLAYLIST_FIELDS
 
     def test_configures_auth(self):
         client = web.SpotifyOAuthClient("1234567", "AbCdEfG", None)


### PR DESCRIPTION
Third time lucky here. This is the Python 3 version of https://github.com/mopidy/mopidy-spotify/pull/228 aimed at fixing #140 and #182. Everything discussed in the previous PR is probably still valid for this version.

- [x] Cache playlist API response data
- [x] Support Spotify's new playlist URI scheme
- [x] ~~Save cached data to file on exit and restore on login~~ - not in this PR
- [ ] Translator should use @memoized decorator?
- [x] Track translators need to consider market availability
- [x] Tests
- [x] Handle playlists refresh
- [x] Include performance info

I have redone the performance measurements that I included in the commits for #228 which helped explained the code's evolution.

I'm *still* not happy with returning the raw (mutable) cache data dict to `SpotifyOAuthClient` and this led to the hacky workaround: https://github.com/mopidy/mopidy-spotify/blob/681debe77d46d233f792c7e64b1c76fc7bfff71e/mopidy_spotify/web.py#L462-L465. Returning something immutable like a `namedtuple` might be better or something Python 3-ish (dataclass?). 