### PR TITLE
Support for playlist management (creation and tracks add/rm/swap).

### DIFF
--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -52,6 +52,33 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
             as_items,
         )
 
+    def _playlist_edit(self, playlist, method, **kwargs):
+        user_id = playlist.uri.split(':')[-3]
+        playlist_id = playlist.uri.split(':')[-1]
+        url = f'users/{user_id}/playlists/{playlist_id}/tracks'
+        method = getattr(self._backend._web_client, method.lower())
+        if not method:
+            self.logger.error(f'Invalid HTTP method "{method}"')
+            return playlist
+
+        logger.debug(f'API request: {method} {url}')
+        response = method(
+                url, headers={'Content-Type': 'application/json'}, json=kwargs)
+
+        logger.debug(f'API response: {response}')
+
+        if response and 'error' not in response:
+            # TODO invalidating the whole cache is probably a bit much if we have
+            # updated only one playlist - maybe we should expose an API to clear
+            # cache items by key?
+            self._backend._web_client.clear_cache()
+            return self.lookup(playlist.uri)
+        else:
+            logging.error('Error on playlist item(s) removal: {}'.format(
+                response['error'] if response else '(Unknown error)'))
+
+            return playlist
+
     def refresh(self):
         if not self._backend._web_client.logged_in:
             return
@@ -68,13 +95,93 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
         self._loaded = True
 
     def create(self, name):
-        pass  # TODO
+        logger.info(f'Creating playlist {name}')
+        url = f'users/{user_id}/playlists'
+        response = self._backend._web_client.post(
+                url, headers={'Content-Type': 'application/json'})
+
+        return self.lookup(response['uri'])
 
     def delete(self, uri):
-        pass  # TODO
+        # Playlist deletion is not implemented in the web API, see
+        # https://github.com/spotify/web-api/issues/555
+        pass
 
     def save(self, playlist):
-        pass  # TODO
+        # Note that for sake of simplicity the diff calculation between the
+        # old and new playlist won't take duplicate items into account
+        # (i.e. tracks that occur multiple times in the same playlist)
+        saved_playlist = self.lookup(playlist.uri)
+        if not saved_playlist:
+            return
+
+        new_tracks = {track.uri: track for track in playlist.tracks}
+        cur_tracks = {track.uri: track for track in saved_playlist.tracks}
+        removed_uris = set([track.uri
+            for track in saved_playlist.tracks
+            if track.uri not in new_tracks])
+
+        # Remove tracks logic
+        if removed_uris:
+            logger.info('Removing {} tracks from playlist {}: {}'.format(
+                len(removed_uris), playlist.name, removed_uris))
+
+            cur_tracks = {
+                track.uri: track
+                for track in self._playlist_edit(
+                    playlist, method='delete',
+                    tracks=[{'uri': uri for uri in removed_uris}]).tracks
+                }
+
+        # Add tracks logic
+        position = None
+        added_uris = {}
+
+        for i, track in enumerate(playlist.tracks):
+            if track.uri not in cur_tracks:
+                if position is None:
+                    position = i
+                    added_uris[position] = []
+                added_uris[position].append(track.uri)
+            else:
+                position = None
+
+        if added_uris:
+            for pos, uris in added_uris.items():
+                logger.info(f'Adding {uris} to playlist {playlist.name}')
+
+                cur_tracks = {
+                    track.uri: track
+                    for track in self._playlist_edit(
+                        playlist, method='post',
+                        uris=uris, position=pos).tracks
+                    }
+
+        # Swap tracks logic
+        cur_tracks_by_uri = {}
+
+        for i, track in enumerate(playlist.tracks):
+            if i >= len(saved_playlist.tracks):
+                break
+
+            if track.uri != saved_playlist.tracks[i].uri:
+                cur_tracks_by_uri[saved_playlist.tracks[i].uri] = i
+
+                if track.uri in cur_tracks_by_uri:
+                    cur_pos = cur_tracks_by_uri[track.uri]
+                    new_pos = i+1
+                    logger.info('Moving item position [{}] to [{}] in playlist {}'.
+                                format(cur_pos, new_pos, playlist.name))
+
+                    cur_tracks = {
+                        track.uri: track
+                        for track in self._playlist_edit(
+                            playlist, method='put',
+                            range_start=cur_pos, insert_before=new_pos).tracks
+                        }
+
+        self._backend._web_client.clear_cache()
+        return self.lookup(saved_playlist.uri)
 
 
 def playlist_lookup(session, web_client, uri, bitrate, as_items=False):

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -95,8 +95,7 @@ class OAuthClient:
         result = self._request_with_retries(method.upper(), path, *args, **kwargs)
 
         if result is None or "error" in result:
-            logger.error('Spotify web API call failed: {} {}: {}'.format(
-                method.upper(), path, result))
+            logger.error(f'Spotify web API call failed: {method.upper()} {path}: {result}')
             return {}
 
         if self._should_cache_response(cache, result):

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -65,7 +65,7 @@ class OAuthClient:
         self._headers = {"Content-Type": "application/json"}
         self._session = utils.get_requests_session(proxy_config or {})
 
-    def get(self, path, cache=None, *args, **kwargs):
+    def request(self, method, path, *args, cache=None, **kwargs):
         if self._authorization_failed:
             logger.debug("Blocking request as previous authorization failed.")
             return {}
@@ -82,7 +82,6 @@ class OAuthClient:
                 return cached_result
             kwargs.setdefault("headers", {}).update(cached_result.etag_headers)
 
-        # TODO: Factor this out once we add more methods.
         # TODO: Don't silently error out.
         try:
             if self._should_refresh_token():
@@ -93,9 +92,11 @@ class OAuthClient:
 
         # Make sure our headers always override user supplied ones.
         kwargs.setdefault("headers", {}).update(self._headers)
-        result = self._request_with_retries("GET", path, *args, **kwargs)
+        result = self._request_with_retries(method.upper(), path, *args, **kwargs)
 
         if result is None or "error" in result:
+            logger.error('Spotify web API call failed: {} {}: {}'.format(
+                method.upper(), path, result))
             return {}
 
         if self._should_cache_response(cache, result):
@@ -105,6 +106,18 @@ class OAuthClient:
             cache[path] = result
 
         return result
+
+    def get(self, path, cache=None, *args, **kwargs):
+        return self.request('GET', path, cache, *args, **kwargs)
+
+    def post(self, path, *args, **kwargs):
+        return self.request('POST', path, cache=None, *args, **kwargs)
+
+    def put(self, path, *args, **kwargs):
+        return self.request('PUT', path, cache=None, *args, **kwargs)
+
+    def delete(self, path, *args, **kwargs):
+        return self.request('DELETE', path, cache=None, *args, **kwargs)
 
     def _should_cache_response(self, cache, response):
         return cache is not None and response.status_ok


### PR DESCRIPTION
MPD isn't that optimal in managing playlist changes - it sends the whole snapshot of the new playlist to the `save` method, while the Spotify Web API only requires the track changes to be submitted. It means that we have to build the deltas within the `save` method itself. This implementation gets the job done but I'm sure that it could be further optimized.

Known limitations:

- In order to make the delta calculation a bit more optimized the old and new playlists are currently indexed by track `uri`. It means that things can get messy if a playlist has duplicate track URIs - if a user removes an instance of a track that appears twice in the playlist then both the instances will be removed, if a user adds a track to a playlist where the track is already present then no changes will be calculated (this isn't such a bad thing IMHO, even the Spotify frontend asks for user confirmation if a track is added to a playlist where it's already present).

- The current implementation won't allow the invalidation of single cache items. It means that we have to call `self._backend._web_client.clear_cache()` and invalidate the whole cache even if we have changed only one playlist.

- The `save` method doesn't look that good now, as it handles removals, additions and swaps within the same block and progressively updates the `cur_tracks` map. I believe however that it can be split into three distinct `rm`, `add` and `swap` methods: all the MPD clients I know allow user interactions that fall into only one of those categories, not "bulk edits" that require a whole playlist to be updated through multiple rm/add/swap at the same time.

- Tests should be added.