### PR TITLE
Use Web API for personal top tracks and artists.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ Changelog
 *********
 
 
+v4.0.0a3 (UNRELEASED)
+=====================
+
+Alpha release.
+
+- Use the Spotify Web API for personal top lists. (PR: #237)
+
+
 v4.0.0a2 (2019-12-12)
 =====================
 

--- a/README.rst
+++ b/README.rst
@@ -38,10 +38,6 @@ Mopidy-Spotify support for the following:
   `#108 <https://github.com/mopidy/mopidy-spotify/issues/108>`_) - available via
   web API
 
-- Top Tracks/curated playlists (`#140 
-  <https://github.com/mopidy/mopidy-spotify/issues/140>`_) - available via web
-  API
-
 - Podcasts (`#201 <https://github.com/mopidy/mopidy-spotify/issues/201>`_) -
   unavailable
 
@@ -57,6 +53,8 @@ Working support for the following features is currently available:
 - Search
 
 - Playlists
+
+- Top lists
 
 - Lookup by URI
 

--- a/mopidy_spotify/browse.py
+++ b/mopidy_spotify/browse.py
@@ -33,7 +33,7 @@ _TOPLIST_REGIONS = {
 }
 
 
-def browse(config, session, webclient, uri):
+def browse(*, config, session, web_client, uri):
     if uri == ROOT_DIR.uri:
         return _ROOT_DIR_CONTENTS
     elif uri == _TOPLIST_DIR.uri:
@@ -50,7 +50,7 @@ def browse(config, session, webclient, uri):
             return _browse_toplist_regions(variant=parts[0])
         elif len(parts) == 2:
             if parts[1] == "user":
-                return _browse_toplist_user(webclient, variant=parts[0])
+                return _browse_toplist_user(web_client, variant=parts[0])
             return _browse_toplist(
                 config, session, variant=parts[0], region=parts[1]
             )
@@ -120,14 +120,16 @@ def _browse_toplist_regions(variant):
     return dir_contents
 
 
-def _browse_toplist_user(webclient, variant):
-    if not webclient.logged_in:
+def _browse_toplist_user(web_client, variant):
+    if not web_client.logged_in:
         return []
 
     if variant in ("tracks", "artists"):
-        items = webclient.get_one(f"me/top/{variant}").get("items", [])
+        items = web_client.get_one(f"me/top/{variant}").get("items", [])
         if variant == "tracks":
-            return list(translator.web_to_track_refs(items, False))
+            return list(
+                translator.web_to_track_refs(items, check_playable=False)
+            )
         else:
             return list(translator.web_to_artist_refs(items))
     else:

--- a/mopidy_spotify/browse.py
+++ b/mopidy_spotify/browse.py
@@ -9,7 +9,13 @@ logger = logging.getLogger(__name__)
 
 ROOT_DIR = models.Ref.directory(uri="spotify:directory", name="Spotify")
 
+_TOPLIST_DIR = models.Ref.directory(uri="spotify:top:lists", name="Top lists")
+
 _ROOT_DIR_CONTENTS = [
+    _TOPLIST_DIR,
+]
+
+_TOPLIST_DIR_CONTENTS = [
     models.Ref.directory(uri="spotify:top:tracks", name="Top tracks"),
     models.Ref.directory(uri="spotify:top:albums", name="Top albums"),
     models.Ref.directory(uri="spotify:top:artists", name="Top artists"),
@@ -22,15 +28,16 @@ _TOPLIST_TYPES = {
 }
 
 _TOPLIST_REGIONS = {
-    "user": lambda session: spotify.ToplistRegion.USER,
     "country": lambda session: session.user_country,
     "everywhere": lambda session: spotify.ToplistRegion.EVERYWHERE,
 }
 
 
-def browse(config, session, uri):
+def browse(config, session, webclient, uri):
     if uri == ROOT_DIR.uri:
         return _ROOT_DIR_CONTENTS
+    elif uri == _TOPLIST_DIR.uri:
+        return _TOPLIST_DIR_CONTENTS
     elif uri.startswith("spotify:user:"):
         return _browse_playlist(session, uri, config)
     elif uri.startswith("spotify:album:"):
@@ -42,14 +49,16 @@ def browse(config, session, uri):
         if len(parts) == 1:
             return _browse_toplist_regions(variant=parts[0])
         elif len(parts) == 2:
+            if parts[1] == "user":
+                return _browse_toplist_user(webclient, variant=parts[0])
             return _browse_toplist(
                 config, session, variant=parts[0], region=parts[1]
             )
         else:
-            logger.info(f'Failed to browse "{uri}": Toplist URI parsing failed')
+            logger.info(f"Failed to browse {uri!r}: Toplist URI parsing failed")
             return []
     else:
-        logger.info(f'Failed to browse "{uri}": Unknown URI type')
+        logger.info(f"Failed to browse {uri!r}: Unknown URI type")
         return []
 
 
@@ -90,10 +99,7 @@ def _browse_artist(session, uri, config):
 
 
 def _browse_toplist_regions(variant):
-    return [
-        models.Ref.directory(
-            uri=f"spotify:top:{variant}:user", name="Personal"
-        ),
+    dir_contents = [
         models.Ref.directory(
             uri=f"spotify:top:{variant}:country", name="Country"
         ),
@@ -104,6 +110,28 @@ def _browse_toplist_regions(variant):
             uri=f"spotify:top:{variant}:everywhere", name="Global"
         ),
     ]
+    if variant in ("tracks", "artists"):
+        dir_contents.insert(
+            0,
+            models.Ref.directory(
+                uri=f"spotify:top:{variant}:user", name="Personal"
+            ),
+        )
+    return dir_contents
+
+
+def _browse_toplist_user(webclient, variant):
+    if not webclient.logged_in:
+        return []
+
+    if variant in ("tracks", "artists"):
+        items = webclient.get_one(f"me/top/{variant}").get("items", [])
+        if variant == "tracks":
+            return list(translator.web_to_track_refs(items, False))
+        else:
+            return list(translator.web_to_artist_refs(items))
+    else:
+        return []
 
 
 def _browse_toplist(config, session, variant, region):
@@ -119,7 +147,7 @@ def _browse_toplist(config, session, variant, region):
             for code in codes
         ]
 
-    if region in ("user", "country", "everywhere"):
+    if region in ("country", "everywhere"):
         sp_toplist = session.get_toplist(
             type=_TOPLIST_TYPES[variant],
             region=_TOPLIST_REGIONS[region](session),

--- a/mopidy_spotify/library.py
+++ b/mopidy_spotify/library.py
@@ -15,7 +15,9 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
         self._config = backend._config["spotify"]
 
     def browse(self, uri):
-        return browse.browse(self._config, self._backend._session, uri)
+        return browse.browse(
+            self._config, self._backend._session, self._backend._web_client, uri
+        )
 
     def get_distinct(self, field, query=None):
         return distinct.get_distinct(

--- a/mopidy_spotify/library.py
+++ b/mopidy_spotify/library.py
@@ -16,7 +16,10 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
 
     def browse(self, uri):
         return browse.browse(
-            self._config, self._backend._session, self._backend._web_client, uri
+            config=self._config,
+            session=self._backend._session,
+            web_client=self._backend._web_client,
+            uri=uri,
         )
 
     def get_distinct(self, field, query=None):

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -162,7 +162,7 @@ def to_track_refs(sp_tracks, timeout=None):
             yield ref
 
 
-def web_to_track_ref(web_track, check_playable=True):
+def web_to_track_ref(web_track, *, check_playable=True):
     if not valid_web_data(web_track, "track"):
         return
 
@@ -177,10 +177,10 @@ def web_to_track_ref(web_track, check_playable=True):
     return models.Ref.track(uri=uri, name=web_track.get("name"))
 
 
-def web_to_track_refs(web_tracks, check_playable=True):
+def web_to_track_refs(web_tracks, *, check_playable=True):
     for web_track in web_tracks:
         web_track = web_track.get("track", web_track)
-        ref = web_to_track_ref(web_track, check_playable)
+        ref = web_to_track_ref(web_track, check_playable=check_playable)
         if ref is not None:
             yield ref
 

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -203,6 +203,15 @@ def test_browse_unsupported_top_tracks(web_client_mock, provider):
     assert len(results) == 0
 
 
+def test_browse_personal_top_tracks_empty(web_client_mock, provider):
+    web_client_mock.get_one.return_value = {}
+
+    results = provider.browse("spotify:top:tracks:user")
+
+    web_client_mock.get_one.assert_called_once_with("me/top/tracks")
+    assert len(results) == 0
+
+
 def test_browse_personal_top_tracks(web_client_mock, web_track_mock, provider):
     # The tracks from this endpoint are erroneously missing some fields:
     del web_track_mock["is_playable"]


### PR DESCRIPTION
Personal top albums are not available using the Web API.

Also pushed the toplists down a directory level ready for adding the functionality from mopidy-spotify-web.