### PR TITLE
Support browsing of albums and tracks from the "Your music" library

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ v4.0.0a3 (UNRELEASED)
 Alpha release.
 
 - Use the Spotify Web API for personal top lists. (PR: #237)
+- Use the Spotify Web API to support browsing Your Music. (#16, PR: #238)
 
 
 v4.0.0a2 (2019-12-12)

--- a/README.rst
+++ b/README.rst
@@ -34,9 +34,8 @@ way for us to provide some Spotify features.
 Limitations and/or bugs in ``libspotify`` currently result in missing/broken
 Mopidy-Spotify support for the following:
 
-- My Music (`#16 <https://github.com/mopidy/mopidy-spotify/issues/16>`_,
-  `#108 <https://github.com/mopidy/mopidy-spotify/issues/108>`_) - available via
-  web API
+- Saving items to My Music (`#108 <https://github.com/mopidy/mopidy-spotify/issues/108>`_) -
+  possible via web API
 
 - Podcasts (`#201 <https://github.com/mopidy/mopidy-spotify/issues/201>`_) -
   unavailable
@@ -52,9 +51,9 @@ Working support for the following features is currently available:
 
 - Search
 
-- Playlists
+- Playlists (read-only)
 
-- Top lists
+- Top lists and Your Music (read-only)
 
 - Lookup by URI
 

--- a/mopidy_spotify/browse.py
+++ b/mopidy_spotify/browse.py
@@ -9,13 +9,13 @@ logger = logging.getLogger(__name__)
 
 ROOT_DIR = models.Ref.directory(uri="spotify:directory", name="Spotify")
 
-_TOPLIST_DIR = models.Ref.directory(uri="spotify:top:lists", name="Top lists")
+_TOP_LIST_DIR = models.Ref.directory(uri="spotify:top", name="Top lists")
 
 _ROOT_DIR_CONTENTS = [
-    _TOPLIST_DIR,
+    _TOP_LIST_DIR,
 ]
 
-_TOPLIST_DIR_CONTENTS = [
+_TOP_LIST_DIR_CONTENTS = [
     models.Ref.directory(uri="spotify:top:tracks", name="Top tracks"),
     models.Ref.directory(uri="spotify:top:albums", name="Top albums"),
     models.Ref.directory(uri="spotify:top:artists", name="Top artists"),
@@ -36,8 +36,8 @@ _TOPLIST_REGIONS = {
 def browse(*, config, session, web_client, uri):
     if uri == ROOT_DIR.uri:
         return _ROOT_DIR_CONTENTS
-    elif uri == _TOPLIST_DIR.uri:
-        return _TOPLIST_DIR_CONTENTS
+    elif uri == _TOP_LIST_DIR.uri:
+        return _TOP_LIST_DIR_CONTENTS
     elif uri.startswith("spotify:user:"):
         return _browse_playlist(session, uri, config)
     elif uri.startswith("spotify:album:"):

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -105,6 +105,22 @@ def to_album_refs(sp_albums, timeout=None):
             yield ref
 
 
+def web_to_album_ref(web_album):
+    if not valid_web_data(web_album, "album"):
+        return
+
+    return models.Ref.album(uri=web_album["uri"], name=web_album.get("name"))
+
+
+def web_to_album_refs(web_albums):
+    for web_album in web_albums:
+        # The extra level here is to also support "saved album objects".
+        web_album = web_album.get("album", web_album)
+        ref = web_to_album_ref(web_album)
+        if ref is not None:
+            yield ref
+
+
 @memoized
 def to_track(sp_track, bitrate=None):
     if not sp_track.is_loaded:
@@ -179,6 +195,7 @@ def web_to_track_ref(web_track, *, check_playable=True):
 
 def web_to_track_refs(web_tracks, *, check_playable=True):
     for web_track in web_tracks:
+        # The extra level here is to also support "saved track objects".
         web_track = web_track.get("track", web_track)
         ref = web_to_track_ref(web_track, check_playable=check_playable)
         if ref is not None:

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -15,14 +15,11 @@ def test_browse_root_directory(provider):
     results = provider.browse("spotify:directory")
 
     assert len(results) == 1
-    assert (
-        models.Ref.directory(uri="spotify:top:lists", name="Top lists")
-        in results
-    )
+    assert models.Ref.directory(uri="spotify:top", name="Top lists") in results
 
 
 def test_browse_top_lists_directory(provider):
-    results = provider.browse("spotify:top:lists")
+    results = provider.browse("spotify:top")
 
     assert len(results) == 3
     assert (


### PR DESCRIPTION
Thought I needed to rejig the translator to support simple and full web objects. However, it actually turns out can get away with not doing that since can still load albums using libspotify. So have ripped that back out to simplify this change. 

Done tests.