### PR TITLE
Initial support for saving Spotify playlists.

### DIFF
--- a/mopidy_spotify/browse.py
+++ b/mopidy_spotify/browse.py
@@ -148,7 +148,7 @@ def _browse_toplist_user(web_client, variant):
         return []
 
     if variant in ("tracks", "artists"):
-        items = web_client.get_one(f"me/top/{variant}").get("items", [])
+        items = web_client.get_one(f"me/top/{variant}", True).get("items", [])
         if variant == "tracks":
             return list(
                 translator.web_to_track_refs(items, check_playable=False)
@@ -214,7 +214,7 @@ def _browse_your_music(web_client, variant):
 
     if variant in ("tracks", "albums"):
         items = web_client.get_one(
-            f"me/{variant}", params={"market": "from_token"},
+            f"me/{variant}", True, params={"market": "from_token"}
         ).get("items", [])
         if variant == "tracks":
             return list(translator.web_to_track_refs(items))
@@ -230,7 +230,7 @@ def _browse_playlists(web_client, variant):
 
     if variant == "featured":
         items = (
-            web_client.get_one(f"browse/{variant}")
+            web_client.get_one(f"browse/{variant}", True)
             .get("playlists", {})
             .get("items", [])
         )

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -78,7 +78,7 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
         for track in playlist.tracks:
             if track.uri.split(':')[0] != 'spotify':
                 logger.warning('Spotify cannot save playlist containing uri %s',
-                                track.uri)
+                               track.uri)
                 return None
 
         self._backend._web_client.save_playlist(playlist)

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 from mopidy import backend
 
@@ -79,17 +78,17 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
         for track in playlist.tracks:
             if track.uri.split(':')[0] != 'spotify':
                 logger.warning('Spotify cannot save playlist containing uri %s',
-                    track.uri)
+                        track.uri)
                 return None
 
-        logger.info('Saving Playlist')
         self._backend._web_client.save_playlist(playlist)
         # We must force the web client to refresh the playlist
         # or it will return the un-modified version from the cache
         return self._get_playlist(playlist.uri, False)
 
-def playlist_lookup(session, web_client, uri, bitrate, as_items=False, 
-    use_cache=True):
+
+def playlist_lookup(session, web_client, uri, bitrate, as_items=False,
+        use_cache=True):
 
     if web_client is None or not web_client.logged_in:
         return
@@ -123,5 +122,5 @@ def playlist_lookup(session, web_client, uri, bitrate, as_items=False,
                 _sp_links[track.uri] = session.get_link(track.uri)
             except ValueError as exc:
                 logger.info(f"Failed to get link {track.uri!r}: {exc}")
-    
+
     return playlist

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -78,7 +78,7 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
         for track in playlist.tracks:
             if track.uri.split(':')[0] != 'spotify':
                 logger.warning('Spotify cannot save playlist containing uri %s',
-                        track.uri)
+                                track.uri)
                 return None
 
         self._backend._web_client.save_playlist(playlist)
@@ -88,7 +88,7 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
 
 
 def playlist_lookup(session, web_client, uri, bitrate, as_items=False,
-        use_cache=True):
+                    use_cache=True):
 
     if web_client is None or not web_client.logged_in:
         return

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -78,7 +78,7 @@ class OAuthClient:
         path = self._normalise_query_string(path, params)
 
         request_type = kwargs.pop('type', 'GET')
-        _trace('Request type %s, path %s',request_type, path)
+        _trace('Request type %s, path %s', request_type, path)
 
         ignore_expiry = kwargs.pop("ignore_expiry", False)
         if cache is not None and path in cache:
@@ -448,7 +448,7 @@ class SpotifyOAuthClient(OAuthClient):
 
     def save_playlist(self, playlist):
         playlistid = playlist.uri.split(':')[2]
-        logger.info('Saving Playlist %s',playlist.uri)
+        logger.info('Saving Playlist %s', playlist.uri)
         url = 'playlists/%s/tracks' % playlistid
         tracks = []
         for track in playlist.tracks:

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -234,7 +234,7 @@ def test_browse_personal_top_tracks_empty(web_client_mock, provider):
 
     results = provider.browse("spotify:top:tracks:user")
 
-    web_client_mock.get_one.assert_called_once_with("me/top/tracks")
+    web_client_mock.get_one.assert_called_once_with("me/top/tracks", True)
     assert len(results) == 0
 
 
@@ -247,7 +247,7 @@ def test_browse_personal_top_tracks(web_client_mock, web_track_mock, provider):
 
     results = provider.browse("spotify:top:tracks:user")
 
-    web_client_mock.get_one.assert_called_once_with("me/top/tracks")
+    web_client_mock.get_one.assert_called_once_with("me/top/tracks", True)
     assert len(results) == 2
     assert results[0] == models.Ref.track(
         uri="spotify:track:abc", name="ABC 123"
@@ -398,7 +398,7 @@ def test_browse_personal_top_artists(
 
     results = provider.browse("spotify:top:artists:user")
 
-    web_client_mock.get_one.assert_called_once_with("me/top/artists")
+    web_client_mock.get_one.assert_called_once_with("me/top/artists", True)
     assert len(results) == 2
     assert results[0] == models.Ref.artist(
         uri="spotify:artist:abba", name="ABBA"
@@ -446,7 +446,8 @@ def test_browse_your_music_tracks(web_client_mock, web_track_mock, provider):
     results = provider.browse("spotify:your:tracks")
 
     web_client_mock.get_one.assert_called_once_with(
-        "me/tracks", params={"market": "from_token"}
+        "me/tracks", params={"market": "from_token"},
+        True
     )
     assert results == [results[0], results[0]]
     assert results[0] == models.Ref.track(
@@ -463,7 +464,8 @@ def test_browse_your_music_albums(web_client_mock, web_album_mock, provider):
     results = provider.browse("spotify:your:albums")
 
     web_client_mock.get_one.assert_called_once_with(
-        "me/albums", params={"market": "from_token"}
+        "me/albums", params={"market": "from_token"},
+        True
     )
     assert results == [results[0], results[0]]
     assert results[0] == models.Ref.album(

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -73,7 +73,8 @@ def test_browse_playlist(web_client_mock, web_playlist_mock, provider):
     results = provider.browse("spotify:user:alice:playlist:foo")
 
     web_client_mock.get_playlist.assert_called_once_with(
-        "spotify:user:alice:playlist:foo"
+        "spotify:user:alice:playlist:foo",
+        True
     )
     assert len(results) == 1
     assert results[0] == models.Ref.track(

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -446,8 +446,7 @@ def test_browse_your_music_tracks(web_client_mock, web_track_mock, provider):
     results = provider.browse("spotify:your:tracks")
 
     web_client_mock.get_one.assert_called_once_with(
-        "me/tracks", params={"market": "from_token"},
-        True
+        "me/tracks", True, params={"market": "from_token"},
     )
     assert results == [results[0], results[0]]
     assert results[0] == models.Ref.track(
@@ -464,8 +463,7 @@ def test_browse_your_music_albums(web_client_mock, web_album_mock, provider):
     results = provider.browse("spotify:your:albums")
 
     web_client_mock.get_one.assert_called_once_with(
-        "me/albums", params={"market": "from_token"},
-        True
+        "me/albums", True, params={"market": "from_token"},
     )
     assert results == [results[0], results[0]]
     assert results[0] == models.Ref.album(

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -170,7 +170,8 @@ def test_lookup_of_playlist_uri(
 
     session_mock.get_link.assert_called_once_with("spotify:track:abc")
     web_client_mock.get_playlist.assert_called_once_with(
-        "spotify:playlist:alice:foo"
+        "spotify:playlist:alice:foo",
+        True
     )
 
     assert len(results) == 1

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -149,8 +149,8 @@ def test_refresh_loads_all_playlists(provider, web_client_mock):
     web_client_mock.get_user_playlists.assert_called_once()
     assert web_client_mock.get_playlist.call_count == 2
     expected_calls = [
-        mock.call("spotify:user:alice:playlist:foo"),
-        mock.call("spotify:user:bob:playlist:baz"),
+        mock.call("spotify:user:alice:playlist:foo", True),
+        mock.call("spotify:user:bob:playlist:baz", True),
     ]
     web_client_mock.get_playlist.assert_has_calls(expected_calls)
 
@@ -248,6 +248,7 @@ def test_playlist_lookup_stores_track_link(
         "spotify:user:alice:playlist:foo",
         None,
         as_items,
+        True
     )
 
     session_mock.get_link.assert_called_once_with("spotify:track:abc")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -774,7 +774,7 @@ class TestSpotifyOAuthClient:
             responses.GET, self.url("foo"), json={"error": "bar"},
         )
 
-        result = spotify_client.get_one("foo", json={})
+        result = spotify_client.get_one("foo", True, json={})
 
         assert result == {}
         assert "Spotify Web API request failed: bar" in caplog.text
@@ -783,8 +783,8 @@ class TestSpotifyOAuthClient:
     def test_get_one_cached(self, spotify_client):
         responses.add(responses.GET, self.url("foo"))
 
-        spotify_client.get_one("foo")
-        spotify_client.get_one("foo")
+        spotify_client.get_one("foo", True)
+        spotify_client.get_one("foo", True)
 
         assert len(responses.calls) == 1
         assert "foo" in spotify_client._cache
@@ -794,7 +794,7 @@ class TestSpotifyOAuthClient:
         responses.add(responses.GET, self.url("foo"))
         mock_time.return_value = 1000
 
-        result = spotify_client.get_one("foo")
+        result = spotify_client.get_one("foo", True)
 
         assert 1000 + spotify_client.DEFAULT_EXTRA_EXPIRY == result._expires
 
@@ -884,7 +884,7 @@ class TestSpotifyOAuthClient:
         )
         responses.add(responses.GET, self.url("playlists/fake"), json=None)
 
-        result = spotify_client.get_playlist(uri)
+        result = spotify_client.get_playlist(uri, True)
 
         if success:
             assert result == web_playlist_mock
@@ -895,7 +895,7 @@ class TestSpotifyOAuthClient:
     def test_get_playlist_sets_params_for_playlist(self, spotify_client):
         responses.add(responses.GET, self.url("playlists/foo"), json={})
 
-        spotify_client.get_playlist("spotify:playlist:foo")
+        spotify_client.get_playlist("spotify:playlist:foo", True)
 
         assert len(responses.calls) == 1
         encoded_params = urllib.parse.urlencode(
@@ -911,7 +911,7 @@ class TestSpotifyOAuthClient:
             responses.GET, self.url("playlists/foo"), json={"error": "bar"},
         )
 
-        result = spotify_client.get_playlist("spotify:playlist:foo")
+        result = spotify_client.get_playlist("spotify:playlist:foo", True)
 
         assert result == {}
         assert "Spotify Web API request failed: bar" in caplog.text
@@ -929,7 +929,7 @@ class TestSpotifyOAuthClient:
             json={"error": "baz"},
         )
 
-        result = spotify_client.get_playlist("spotify:playlist:foo")
+        result = spotify_client.get_playlist("spotify:playlist:foo", True)
 
         assert result == {}
         assert "Spotify Web API request failed: baz" in caplog.text
@@ -948,7 +948,7 @@ class TestSpotifyOAuthClient:
         )
         responses.add(responses.GET, self.url("playlists/foo/tracks2"), json={})
 
-        spotify_client.get_playlist("spotify:playlist:foo")
+        spotify_client.get_playlist("spotify:playlist:foo", True)
 
         assert len(responses.calls) == 3
         encoded_params = urllib.parse.urlencode(
@@ -974,7 +974,7 @@ class TestSpotifyOAuthClient:
             json={"items": [3, 4, 5]},
         )
 
-        result = spotify_client.get_playlist("spotify:playlist:foo")
+        result = spotify_client.get_playlist("spotify:playlist:foo", True)
 
         assert len(responses.calls) == 2
         assert result["tracks"]["items"] == [1, 2, 3, 4, 5]
@@ -996,7 +996,7 @@ class TestSpotifyOAuthClient:
         )
         mock_time.return_value = -1000
 
-        result1 = spotify_client.get_playlist("spotify:playlist:foo")
+        result1 = spotify_client.get_playlist("spotify:playlist:foo", True)
 
         assert len(responses.calls) == 2
         assert result1["tracks"]["items"] == [1, 2, 3, 4, 5]
@@ -1018,7 +1018,7 @@ class TestSpotifyOAuthClient:
         ],
     )
     def test_get_playlist_error_msg(self, spotify_client, caplog, uri, msg):
-        assert spotify_client.get_playlist(uri) == {}
+        assert spotify_client.get_playlist(uri, True) == {}
         assert f"Could not parse {uri!r} as a {msg} URI" in caplog.text
 
     def test_clear_cache(self, spotify_client):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1005,7 +1005,7 @@ class TestSpotifyOAuthClient:
         responses.calls.reset()
         mock_time.return_value = 1000
 
-        result2 = spotify_client.get_playlist("spotify:playlist:foo")
+        result2 = spotify_client.get_playlist("spotify:playlist:foo", True)
 
         assert len(responses.calls) == 1
         assert result1["tracks"]["items"] == result2["tracks"]["items"]


### PR DESCRIPTION
This adds support for the 'save' function in playlists.py, using the web api client.

Pretty simple stuff, just had to add an extra parameter so I could force it to refresh the playlist after the save, otherwise it returned the cached copy which made it appear to a mopidy client that nothing had happened.