### PR TITLE
Fix gapless playback

### DIFF
--- a/mopidy_spotify/playback.py
+++ b/mopidy_spotify/playback.py
@@ -208,6 +208,9 @@ def end_of_track_callback(session, end_of_track_event, audio_actor):
     end_of_track_event.set()
     audio_actor.emit_data(None)
 
+    # unload the player to stop receiving data
+    session.player.unload()
+
 
 class BufferTimestamp:
     """Wrapper around an int to serialize access by multiple threads.

--- a/mopidy_spotify/playback.py
+++ b/mopidy_spotify/playback.py
@@ -195,16 +195,14 @@ def music_delivery_callback(
         bytes(frames), timestamp=buffer_timestamp.get(), duration=duration
     )
 
+    # If there is any held buffer, send it
     if _held_buffer:
-
-        # Send any queued buffer first.
-        future = audio_actor.emit_data(_held_buffer)
+        consumed = audio_actor.emit_data(_held_buffer).get()
+    else:
+        consumed = True
 
     # libspotify sends an empty buffer before calling end_of_track_callback, so we need to hold it.
     _held_buffer = buffer_
-
-    # We must block here to know if the buffer was consumed successfully.
-    consumed = future.get()
 
     if consumed:
         buffer_timestamp.increase(duration)

--- a/mopidy_spotify/playback.py
+++ b/mopidy_spotify/playback.py
@@ -80,14 +80,14 @@ class SpotifyPlaybackProvider(backend.PlaybackProvider):
         self._first_seek = True
         self._end_of_track_event.clear()
 
+        # Discard held buffer
+        _held_buffer = None
+
         try:
             sp_track = self.backend._session.get_track(track.uri)
             sp_track.load(self._timeout)
             self.backend._session.player.load(sp_track)
             self.backend._session.player.play()
-
-            # Discard held buffer
-            _held_buffer = None
 
             future = self.audio.set_appsrc(
                 GST_CAPS,


### PR DESCRIPTION
After the song ends, libspotify continues to push data to the buffer, which breaks gapless playback.

This change fixes this by unloading the track after it ends. 

Closes #160.