### PR TITLE
Soaku gapless playback

### DIFF
--- a/mopidy_spotify/playback.py
+++ b/mopidy_spotify/playback.py
@@ -208,6 +208,9 @@ def end_of_track_callback(session, end_of_track_event, audio_actor):
     end_of_track_event.set()
     audio_actor.emit_data(None)
 
+    # unload the player to stop receiving data
+    session.player.unload()
+
 
 class BufferTimestamp:
     """Wrapper around an int to serialize access by multiple threads.

--- a/mopidy_spotify/playback.py
+++ b/mopidy_spotify/playback.py
@@ -80,14 +80,14 @@ class SpotifyPlaybackProvider(backend.PlaybackProvider):
         self._first_seek = True
         self._end_of_track_event.clear()
 
+        # Discard held buffer
+        _held_buffer = None
+
         try:
             sp_track = self.backend._session.get_track(track.uri)
             sp_track.load(self._timeout)
             self.backend._session.player.load(sp_track)
             self.backend._session.player.play()
-
-            # Discard held buffer
-            _held_buffer = None
 
             future = self.audio.set_appsrc(
                 GST_CAPS,


### PR DESCRIPTION
This is #269 with the remaining CI fixes. And also with the held buffer changed from a global to an instance variable as the `music_delivery_callback` tests were no longer doing the right thing.

