### PR TITLE
Organize track info

### DIFF
--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -131,13 +131,13 @@ def clean_track_info(title, artists):
         any(feat.name.lower() in title.lower() for feat in artists)
         and len(artists) > 1
     ):
-        artists = [artists[0]]
+        artists = artists[:1]
     elif (
         not any(feat in title.lower() for feat in FEATURES) and len(artists) > 1
     ):
         feat = ", ".join([artist.name for artist in artists[1:]])
         title = f"{title} (feat. {feat})"
-        artists = [artists[0]]
+        artists = artists[:1]
 
     return title, artists
 


### PR DESCRIPTION
A small function to make the tracks in results and playlists more readable.

`Artist 1;Artist 2 - Title (feat. Artist 2)` ---> `Artist 1 - Title (feat. Artist 2)`
or
`Artist 1;Artist 2 - Title` ---> `Artist 1 - Title (feat. Artist 2)`

From:
![new](https://user-images.githubusercontent.com/59455966/103114125-d4a82d80-4633-11eb-8034-c6d791863b8b.png)
To:
![old](https://user-images.githubusercontent.com/59455966/103114127-d5d95a80-4633-11eb-8987-83488f23111c.png)


