### PR TITLE
Improve web tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -345,14 +345,9 @@ def web_response_mock(web_track_mock):
 
 
 @pytest.fixture
-def web_response_mock_etag(web_track_mock):
-    return web.WebResponse(
-        "https://api.spotify.com/v1/tracks/abc",
-        web_track_mock,
-        expires=1000,
-        etag='"1234"',
-        status_code=200,
-    )
+def web_response_mock_etag(web_response_mock):
+    web_response_mock._etag = '"1234"'
+    return web_response_mock
 
 
 @pytest.fixture


### PR DESCRIPTION
During review/testing of https://github.com/mopidy/mopidy-spotify/pull/287 I realised there's a potential problem with the way we mix relative and absolute URLs when using the web client when it comes to trying to clear specific parts of the cache. So I wanted to be a lot more explicit in the tests and and have the URLs we use more closely match reality. This will be helpful for the PR that addresses this issue.

Plus a fix I had been sitting on for a while which uses the `skip_refresh_token` in the other places it's useful (rather than directly messing about with numbers).