### PR TITLE
Use the long-form Spotify URL for user playlists.

### DIFF
--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -434,7 +434,9 @@ class SpotifyOAuthClient(OAuthClient):
         return self.user_id is not None
 
     def get_user_playlists(self):
-        pages = self.get_all("me/playlists", params={"limit": 50})
+        pages = self.get_all(
+            f"users/{self.user_id}/playlists", params={"limit": 50}
+        )
         for page in pages:
             yield from page.get("items", [])
 


### PR DESCRIPTION
For logged in user 'foo',  Web API endpoint "me/playlists"
returns the same as "users/foo/playlists" (including headers).
When we use the former, the "next" links in the response always use
the latter. This leaves us with a mix of URL formats in our cache
and will make identifying/invalidating these entries harder.

This change ensures all the URLs look the same. No behaviour has
changed.

This will make cache invalidation in #287 a little simpler and makes sense to do anyway.