### PR TITLE
Log when refresh of playlists starts

### DIFF
--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -53,6 +53,8 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
         if not self._backend._web_client.logged_in:
             return
 
+        logger.info("Refreshing Spotify playlists")
+
         with utils.time_logger("playlists.refresh()", logging.DEBUG):
             _sp_links.clear()
             self._backend._web_client.clear_cache()


### PR DESCRIPTION
I have ~1k playlists on my account so a refresh takes about 8 minutes.
The logs gives no indication what is happening and I was confused so
providing an explanation to what is happening would have been useful.

PS. Thanks for a great project! I use mopidy on an RPi and connect it to a bluetooth speaker to always have music playing in my bathroom 🎶 