### PR TITLE
Support lookups for 'your' URIs

### DIFF
--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -486,6 +486,7 @@ class LinkType(Enum):
     ALBUM = "album"
     ARTIST = "artist"
     PLAYLIST = "playlist"
+    YOUR = "your"
 
 
 @dataclass
@@ -519,6 +520,8 @@ class WebLink:
             "playlist",
         ):
             return cls(uri, LinkType(parts[0]), parts[1], None)
+        elif len(parts) == 2 and parts[0] == "your":
+            return cls(uri, LinkType(parts[0]))
         elif len(parts) == 3 and parts[0] == "user" and parts[2] == "starred":
             if parsed_uri.scheme == "spotify":
                 return cls(uri, LinkType.PLAYLIST, None, parts[1])

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1106,6 +1106,7 @@ class TestSpotifyOAuthClient:
         ("spotify:track:bar", web.LinkType.TRACK, "bar"),
         ("spotify:artist:blah", web.LinkType.ARTIST, "blah"),
         ("spotify:album:stuff", web.LinkType.ALBUM, "stuff"),
+        ("spotify:your:albums", web.LinkType.YOUR, None),
     ],
 )
 def test_weblink_from_uri_spotify_uri(uri, type_, id_):


### PR DESCRIPTION
This adds the ability to utilise the "spotify:your:tracks" and
"spotify:your:albums" URIs through library lookups.