### PR TITLE
Do not ignore the `exact` parameter in the `search` method

### DIFF
--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -21,7 +21,6 @@ def search(
     types=_SEARCH_TYPES,
 ):
     # TODO Respect `uris` argument
-    # TODO Support `exact` search
 
     if query is None:
         logger.debug("Ignored search without query")
@@ -30,7 +29,7 @@ def search(
     if "uri" in query:
         return _search_by_uri(config, session, web_client, query)
 
-    sp_query = translator.sp_search_query(query)
+    sp_query = translator.sp_search_query(query, exact)
     if not sp_query:
         logger.debug("Ignored search with empty query")
         return models.SearchResult(uri="spotify:search")

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -265,7 +265,7 @@ SEARCH_FIELD_MAP = {
 }
 
 
-def sp_search_query(query, exact):
+def sp_search_query(query, exact=False):
     """Translate a Mopidy search query to a Spotify search query"""
 
     result = []
@@ -289,7 +289,9 @@ def sp_search_query(query, exact):
                 if exact:
                     result.append(f'{field}:"{value}"')
                 else:
-                    result.append(' '.join(f'{field}:{word}' for word in value.split()))
+                    result.append(
+                        " ".join(f"{field}:{word}" for word in value.split())
+                    )
 
     return " ".join(result)
 

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -265,7 +265,7 @@ SEARCH_FIELD_MAP = {
 }
 
 
-def sp_search_query(query):
+def sp_search_query(query, exact):
     """Translate a Mopidy search query to a Spotify search query"""
 
     result = []
@@ -281,9 +281,15 @@ def sp_search_query(query):
                 if value is not None:
                     result.append(f"{field}:{value}")
             elif field == "any":
-                result.append(f'"{value}"')
+                if exact:
+                    result.append(f'"{value}"')
+                else:
+                    result.append(value)
             else:
-                result.append(f'{field}:"{value}"')
+                if exact:
+                    result.append(f'{field}:"{value}"')
+                else:
+                    result.append(' '.join(f'{field}:{word}' for word in value.split()))
 
     return " ".join(result)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -60,7 +60,7 @@ def test_search_when_offline_returns_nothing(session_mock, provider, caplog):
     assert "Spotify search aborted: Spotify is offline" in caplog.text
 
     assert isinstance(result, models.SearchResult)
-    assert result.uri == "spotify:search:%22ABBA%22"
+    assert result.uri == "spotify:search:ABBA"
     assert len(result.tracks) == 0
 
 
@@ -73,7 +73,7 @@ def test_search_returns_albums_and_artists_and_tracks(
     web_client_mock.get.assert_called_once_with(
         "search",
         params={
-            "q": '"ABBA"',
+            "q": 'ABBA',
             "limit": 50,
             "market": "from_token",
             "type": "album,artist,track",
@@ -83,7 +83,7 @@ def test_search_returns_albums_and_artists_and_tracks(
     assert 'Searching Spotify for: "ABBA"' in caplog.text
 
     assert isinstance(result, models.SearchResult)
-    assert result.uri == "spotify:search:%22ABBA%22"
+    assert result.uri == "spotify:search:ABBA"
 
     assert len(result.albums) == 1
     assert result.albums[0].uri == "spotify:album:def"
@@ -125,7 +125,7 @@ def test_sets_api_limit_to_album_count_when_max(
     web_client_mock.get.assert_called_once_with(
         "search",
         params={
-            "q": '"ABBA"',
+            "q": 'ABBA',
             "limit": 6,
             "market": "from_token",
             "type": "album,artist,track",
@@ -149,7 +149,7 @@ def test_sets_api_limit_to_artist_count_when_max(
     web_client_mock.get.assert_called_once_with(
         "search",
         params={
-            "q": '"ABBA"',
+            "q": 'ABBA',
             "limit": 6,
             "market": "from_token",
             "type": "album,artist,track",
@@ -173,7 +173,7 @@ def test_sets_api_limit_to_track_count_when_max(
     web_client_mock.get.assert_called_once_with(
         "search",
         params={
-            "q": '"ABBA"',
+            "q": 'ABBA',
             "limit": 6,
             "market": "from_token",
             "type": "album,artist,track",
@@ -199,7 +199,7 @@ def test_sets_types_parameter(
     web_client_mock.get.assert_called_once_with(
         "search",
         params={
-            "q": '"ABBA"',
+            "q": 'ABBA',
             "limit": 50,
             "market": "from_token",
             "type": "album,artist",
@@ -217,7 +217,7 @@ def test_sets_market_parameter(
     web_client_mock.get.assert_called_once_with(
         "search",
         params={
-            "q": '"ABBA"',
+            "q": 'ABBA',
             "limit": 50,
             "market": "from_token",
             "type": "album,artist,track",
@@ -231,19 +231,8 @@ def test_handles_empty_response(web_client_mock, provider):
     result = provider.search({"any": ["ABBA"]})
 
     assert isinstance(result, models.SearchResult)
-    assert result.uri == "spotify:search:%22ABBA%22"
+    assert result.uri == "spotify:search:ABBA"
 
     assert len(result.albums) == 0
     assert len(result.artists) == 0
     assert len(result.tracks) == 0
-
-
-def test_exact_is_ignored(
-    session_mock, sp_track_mock, web_client_mock, provider
-):
-    session_mock.get_link.return_value = sp_track_mock.link
-
-    result1 = provider.search({"uri": ["spotify:track:abc"]})
-    result2 = provider.search({"uri": ["spotify:track:abc"]}, exact=True)
-
-    assert result1 == result2

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -80,7 +80,7 @@ def test_search_returns_albums_and_artists_and_tracks(
         },
     )
 
-    assert 'Searching Spotify for: "ABBA"' in caplog.text
+    assert 'Searching Spotify for: ABBA' in caplog.text
 
     assert isinstance(result, models.SearchResult)
     assert result.uri == "spotify:search:ABBA"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -73,7 +73,7 @@ def test_search_returns_albums_and_artists_and_tracks(
     web_client_mock.get.assert_called_once_with(
         "search",
         params={
-            "q": 'ABBA',
+            "q": "ABBA",
             "limit": 50,
             "market": "from_token",
             "type": "album,artist,track",
@@ -125,7 +125,7 @@ def test_sets_api_limit_to_album_count_when_max(
     web_client_mock.get.assert_called_once_with(
         "search",
         params={
-            "q": 'ABBA',
+            "q": "ABBA",
             "limit": 6,
             "market": "from_token",
             "type": "album,artist,track",
@@ -149,7 +149,7 @@ def test_sets_api_limit_to_artist_count_when_max(
     web_client_mock.get.assert_called_once_with(
         "search",
         params={
-            "q": 'ABBA',
+            "q": "ABBA",
             "limit": 6,
             "market": "from_token",
             "type": "album,artist,track",
@@ -173,7 +173,7 @@ def test_sets_api_limit_to_track_count_when_max(
     web_client_mock.get.assert_called_once_with(
         "search",
         params={
-            "q": 'ABBA',
+            "q": "ABBA",
             "limit": 6,
             "market": "from_token",
             "type": "album,artist,track",
@@ -199,7 +199,7 @@ def test_sets_types_parameter(
     web_client_mock.get.assert_called_once_with(
         "search",
         params={
-            "q": 'ABBA',
+            "q": "ABBA",
             "limit": 50,
             "market": "from_token",
             "type": "album,artist",
@@ -217,7 +217,7 @@ def test_sets_market_parameter(
     web_client_mock.get.assert_called_once_with(
         "search",
         params={
-            "q": 'ABBA',
+            "q": "ABBA",
             "limit": 50,
             "market": "from_token",
             "type": "album,artist,track",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -80,7 +80,7 @@ def test_search_returns_albums_and_artists_and_tracks(
         },
     )
 
-    assert 'Searching Spotify for: ABBA' in caplog.text
+    assert "Searching Spotify for: ABBA" in caplog.text
 
     assert isinstance(result, models.SearchResult)
     assert result.uri == "spotify:search:ABBA"

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -597,9 +597,19 @@ class TestSpotifySearchQuery:
     def test_any_maps_to_no_field(self):
         query = translator.sp_search_query({"any": ["ABC", "DEF"]})
 
+        assert query == 'ABC DEF'
+
+    def test_any_maps_to_no_field_exact(self, exact=True):
+        query = translator.sp_search_query({"any": ["ABC", "DEF"]})
+
         assert query == '"ABC" "DEF"'
 
     def test_artist_maps_to_artist(self):
+        query = translator.sp_search_query({"artist": ["ABBA", "ACDC"]})
+
+        assert query == 'artist:ABBA artist:ACDC'
+
+    def test_artist_maps_to_artist_exact(self, exact=True):
         query = translator.sp_search_query({"artist": ["ABBA", "ACDC"]})
 
         assert query == 'artist:"ABBA" artist:"ACDC"'
@@ -609,14 +619,30 @@ class TestSpotifySearchQuery:
 
         query = translator.sp_search_query({"albumartist": ["ABBA", "ACDC"]})
 
-        assert query == 'artist:"ABBA" artist:"ACDC"'
+        assert query == 'artist:ABBA artist:ACDC'
 
+    def test_albumartist_maps_to_artist_exact(self, exact=True):
+        # We don't know how to filter by albumartist in Spotify
+
+        query = translator.sp_search_query({"albumartist": ["ABBA", "ACDC"]})
+
+        assert query == 'artist:"ABBA" artist:"ACDC"'
     def test_album_maps_to_album(self):
+        query = translator.sp_search_query({"album": ["Greatest Hits"]})
+
+        assert query == 'album:Greatest album:Hits'
+
+    def test_album_maps_to_album_exact(self, exact=True):
         query = translator.sp_search_query({"album": ["Greatest Hits"]})
 
         assert query == 'album:"Greatest Hits"'
 
     def test_track_name_maps_to_track(self):
+        query = translator.sp_search_query({"track_name": ["ABC"]})
+
+        assert query == 'track:ABC'
+
+    def test_track_name_maps_to_track_exact(self, exact=True):
         query = translator.sp_search_query({"track_name": ["ABC"]})
 
         assert query == 'track:"ABC"'
@@ -658,9 +684,27 @@ class TestSpotifySearchQuery:
             }
         )
 
-        assert '"ABC"' in query
-        assert '"DEF"' in query
-        assert 'artist:"ABBA"' in query
+        assert 'ABC' in query
+        assert 'DEF' in query
+        assert 'artist:ABBA' in query
+        assert 'album:Greatest album:Hits' in query
+        assert 'track:Dancing track:Queen' in query
+        assert "year:1970" in query
+
+    def test_anything_can_be_combined_exact(self, exact=True):
+        query = translator.sp_search_query(
+            {
+                "any": ["ABC", "DEF"],
+                "artist": ["ABBA"],
+                "album": ["Greatest Hits"],
+                "track_name": ["Dancing Queen"],
+                "year": ["1970-01-02"],
+            }
+        )
+
+        assert 'ABC' in query
+        assert 'DEF' in query
+        assert 'artist:ABBA' in query
         assert 'album:"Greatest Hits"' in query
         assert 'track:"Dancing Queen"' in query
         assert "year:1970" in query

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -597,20 +597,22 @@ class TestSpotifySearchQuery:
     def test_any_maps_to_no_field(self):
         query = translator.sp_search_query({"any": ["ABC", "DEF"]})
 
-        assert query == 'ABC DEF'
+        assert query == "ABC DEF"
 
-    def test_any_maps_to_no_field_exact(self, exact=True):
-        query = translator.sp_search_query({"any": ["ABC", "DEF"]})
+    def test_any_maps_to_no_field_exact(self):
+        query = translator.sp_search_query({"any": ["ABC", "DEF"]}, exact=True)
 
         assert query == '"ABC" "DEF"'
 
     def test_artist_maps_to_artist(self):
         query = translator.sp_search_query({"artist": ["ABBA", "ACDC"]})
 
-        assert query == 'artist:ABBA artist:ACDC'
+        assert query == "artist:ABBA artist:ACDC"
 
-    def test_artist_maps_to_artist_exact(self, exact=True):
-        query = translator.sp_search_query({"artist": ["ABBA", "ACDC"]})
+    def test_artist_maps_to_artist_exact(self):
+        query = translator.sp_search_query(
+            {"artist": ["ABBA", "ACDC"]}, exact=True
+        )
 
         assert query == 'artist:"ABBA" artist:"ACDC"'
 
@@ -619,31 +621,36 @@ class TestSpotifySearchQuery:
 
         query = translator.sp_search_query({"albumartist": ["ABBA", "ACDC"]})
 
-        assert query == 'artist:ABBA artist:ACDC'
+        assert query == "artist:ABBA artist:ACDC"
 
-    def test_albumartist_maps_to_artist_exact(self, exact=True):
+    def test_albumartist_maps_to_artist_exact(self):
         # We don't know how to filter by albumartist in Spotify
 
-        query = translator.sp_search_query({"albumartist": ["ABBA", "ACDC"]})
+        query = translator.sp_search_query(
+            {"albumartist": ["ABBA", "ACDC"]}, exact=True
+        )
 
         assert query == 'artist:"ABBA" artist:"ACDC"'
+
     def test_album_maps_to_album(self):
         query = translator.sp_search_query({"album": ["Greatest Hits"]})
 
-        assert query == 'album:Greatest album:Hits'
+        assert query == "album:Greatest album:Hits"
 
-    def test_album_maps_to_album_exact(self, exact=True):
-        query = translator.sp_search_query({"album": ["Greatest Hits"]})
+    def test_album_maps_to_album_exact(self):
+        query = translator.sp_search_query(
+            {"album": ["Greatest Hits"]}, exact=True
+        )
 
         assert query == 'album:"Greatest Hits"'
 
     def test_track_name_maps_to_track(self):
         query = translator.sp_search_query({"track_name": ["ABC"]})
 
-        assert query == 'track:ABC'
+        assert query == "track:ABC"
 
-    def test_track_name_maps_to_track_exact(self, exact=True):
-        query = translator.sp_search_query({"track_name": ["ABC"]})
+    def test_track_name_maps_to_track_exact(self):
+        query = translator.sp_search_query({"track_name": ["ABC"]}, exact=True)
 
         assert query == 'track:"ABC"'
 
@@ -684,14 +691,14 @@ class TestSpotifySearchQuery:
             }
         )
 
-        assert 'ABC' in query
-        assert 'DEF' in query
-        assert 'artist:ABBA' in query
-        assert 'album:Greatest album:Hits' in query
-        assert 'track:Dancing track:Queen' in query
+        assert "ABC" in query
+        assert "DEF" in query
+        assert "artist:ABBA" in query
+        assert "album:Greatest album:Hits" in query
+        assert "track:Dancing track:Queen" in query
         assert "year:1970" in query
 
-    def test_anything_can_be_combined_exact(self, exact=True):
+    def test_anything_can_be_combined_exact(self):
         query = translator.sp_search_query(
             {
                 "any": ["ABC", "DEF"],
@@ -699,12 +706,13 @@ class TestSpotifySearchQuery:
                 "album": ["Greatest Hits"],
                 "track_name": ["Dancing Queen"],
                 "year": ["1970-01-02"],
-            }
+            },
+            exact=True,
         )
 
-        assert 'ABC' in query
-        assert 'DEF' in query
-        assert 'artist:ABBA' in query
+        assert "ABC" in query
+        assert "DEF" in query
+        assert "artist:ABBA" in query
         assert 'album:"Greatest Hits"' in query
         assert 'track:"Dancing Queen"' in query
         assert "year:1970" in query

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -710,9 +710,9 @@ class TestSpotifySearchQuery:
             exact=True,
         )
 
-        assert "ABC" in query
-        assert "DEF" in query
-        assert "artist:ABBA" in query
+        assert '"ABC"' in query
+        assert '"DEF"' in query
+        assert 'artist:"ABBA"' in query
         assert 'album:"Greatest Hits"' in query
         assert 'track:"Dancing Queen"' in query
         assert "year:1970" in query


### PR DESCRIPTION
Because the `sp_search_query` function has always added double quotes around the query and double quotes instruct the Spotify API to perform exact matching, the `search` function has always performed exact matching, regardless of whether `exact` is `False` or `True`.

https://github.com/mopidy/mopidy-spotify/blob/a4aa63adb291d0c3a6f5af53fe466564b2e4c878/mopidy_spotify/translator.py#L283-L286

Since exact matching has been the only behavior (and therefore the default behavior) since the inception of Mopidy-Spotify, it could be sensible to keep exact matching as the default behavior. However, according to the [Mopidy documentation](https://docs.mopidy.com/en/latest/api/core/#mopidy.core.LibraryController.search), inexact matching is supposed to be the default behavior.