### PR TITLE
search: Remove empty tracks/albums/artists from search results.

### DIFF
--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -77,6 +77,7 @@ def search(
         if "albums" in result
         else []
     )
+    albums = [x for x in albums if x]
 
     artists = (
         [
@@ -88,6 +89,7 @@ def search(
         if "artists" in result
         else []
     )
+    artists = [x for x in artists if x]
 
     tracks = (
         [
@@ -99,6 +101,7 @@ def search(
         if "tracks" in result
         else []
     )
+    tracks = [x for x in tracks if x]
 
     return models.SearchResult(
         uri=uri, albums=albums, artists=artists, tracks=tracks

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -247,3 +247,31 @@ def test_exact_is_ignored(
     result2 = provider.search({"uri": ["spotify:track:abc"]}, exact=True)
 
     assert result1 == result2
+
+
+def test_search_filters_bad_results(
+    web_artist_mock, web_client_mock, web_search_mock, provider, caplog
+):
+    good_track = {
+        "uri": "spotify:track:good",
+        "type": "track",
+        "is_playable": True,
+    }
+    bad_track = {
+        "uri": "spotify:track:bad",
+        "type": "track",
+        "is_playable": False,
+    }
+    web_search_mock["albums"]["items"] = [good_track]
+    web_search_mock["artists"]["items"][0]["uri"] = None
+    web_search_mock["tracks"]["items"] = [{}, good_track, bad_track]
+    web_client_mock.get.return_value = web_search_mock
+    result = provider.search({"any": ["ABBA"]})
+
+    assert isinstance(result, models.SearchResult)
+    assert result.uri == "spotify:search:%22ABBA%22"
+
+    assert len(result.albums) == 0
+    assert len(result.artists) == 0
+    assert len(result.tracks) == 1
+    assert result.tracks[0].uri == "spotify:track:good"


### PR DESCRIPTION
Fixes #280.

Empty (None) Mopidy models were created due to malformed data /
unplayable tracks returned by search endpoint. Must be filtered
out before adding to SearchResults to avoid validation errors.