### PR TITLE
Make thread-safe, retain cache despite refresh

### DIFF
--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -27,11 +27,11 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
 
             return list(self._get_flattened_playlist_refs())
 
-    def _get_flattened_playlist_refs(self):
+    def _get_flattened_playlist_refs(self, force_refresh=True):
         if not self._backend._web_client.logged_in:
             return []
 
-        user_playlists = self._backend._web_client.get_user_playlists()
+        user_playlists = self._backend._web_client.get_user_playlists(force_refresh=force_refresh)
         return translator.to_playlist_refs(
             user_playlists, self._backend._web_client.user_id
         )
@@ -66,10 +66,8 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
         def refresher():
             try:
                 with utils.time_logger("playlists.refresh()", logging.DEBUG):
-                    _sp_links.clear()
-                    self._backend._web_client.clear_cache()
                     count = 0
-                    for playlist_ref in self._get_flattened_playlist_refs():
+                    for playlist_ref in self._get_flattened_playlist_refs(force_refresh=True):
                         self._get_playlist(playlist_ref.uri)
                         count += 1
                     logger.info(f"Refreshed {count} Spotify playlists")

--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum, unique
 from typing import Optional
+from threading import Lock
 
 import requests
 
@@ -116,6 +117,8 @@ class OAuthClient:
 
         self._headers = {"Content-Type": "application/json"}
         self._session = utils.get_requests_session(proxy_config or {})
+        self._cache_mutex = Lock()
+        self._refresh_mutex = Lock()
 
     def get(self, path, cache=None, *args, **kwargs):
         if self._authorization_failed:
@@ -138,11 +141,14 @@ class OAuthClient:
         # TODO: Factor this out once we add more methods.
         # TODO: Don't silently error out.
         try:
+            self._refresh_mutex.acquire()
             if self._should_refresh_token():
                 self._refresh_token()
         except OAuthTokenRefreshError as e:
             logger.error(e)
             return WebResponse(None, None)
+        finally:
+            self._refresh_mutex.release()
 
         # Make sure our headers always override user supplied ones.
         kwargs.setdefault("headers", {}).update(self._headers)
@@ -155,11 +161,15 @@ class OAuthClient:
             )
             return WebResponse(None, None)
 
-        if self._should_cache_response(cache, result):
-            previous_result = cache.get(path)
-            if previous_result and previous_result.updated(result):
-                result = previous_result
-            cache[path] = result
+        try:
+            self._cache_mutex.acquire()
+            if self._should_cache_response(cache, result):
+                previous_result = cache.get(path)
+                if previous_result and previous_result.updated(result):
+                    result = previous_result
+                cache[path] = result
+        finally:
+            self._cache_mutex.release()
 
         return result
 

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -193,8 +193,7 @@ def test_refresh_clears_caches(provider, web_client_mock):
     with ThreadJoiner(timeout=1.0):
         provider.refresh()
 
-    assert "bar" not in playlists._sp_links
-    web_client_mock.clear_cache.assert_called_once()
+    assert "spotify:track:abc" in playlists._sp_links
 
 
 def test_lookup(provider):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -416,7 +416,7 @@ def test_should_cache_response(oauth_client, cache, ok, expected):
     ],
 )
 def test_normalise_query_string(oauth_client, path, params, expected):
-    result = oauth_client._normalise_query_string(path, params)
+    result = web._normalise_query_string(path, params)
     assert result == expected
 
 


### PR DESCRIPTION
Attempt at making #312 thread-safe.

Also:
* Add `force_refresh` parameter to webclient and use it to remove the need for cache-wiping on refresh
* Retry the entire refresh process indefinitely  (this is separate from the per-request exponential backoff), with a 3s interval. (resolves #296, #259 )
* Minor code cleanup