### PR TITLE
tests: fix responses match_querystring deprecation

### DIFF
--- a/mopidy_spotify/web.py
+++ b/mopidy_spotify/web.py
@@ -98,7 +98,7 @@ class OAuthClient:
         if result is None or "error" in result:
             logger.error(
                 "Spotify Web API request failed: "
-                f"{result.get('error','Unknown')}"
+                f"{result.get('error','Unknown') if result else '[no response]'}"
             )
             return WebResponse(None, None)
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -560,13 +560,17 @@ def test_cache_normalised_query_string(
         responses.GET,
         "https://api.spotify.com/v1/tracks/abc?b=bar&f=foo",
         json={"uri": "foobar"},
-        match_querystring=True,
+        match=[
+            responses.matchers.query_param_matcher({"b": "bar", "f": "foo"})
+        ],
     )
     responses.add(
         responses.GET,
         "https://api.spotify.com/v1/tracks/abc?b=bar&f=cat",
         json={"uri": "cat"},
-        match_querystring=True,
+        match=[
+            responses.matchers.query_param_matcher({"b": "bar", "f": "cat"})
+        ],
     )
     mock_time.return_value = 0
 


### PR DESCRIPTION
* Fix test not checking querystring anymore (https://github.com/getsentry/responses/pull/432)
* Fix error logging fail if result is None