### PR TITLE
Fix for empty playlists

### DIFF
--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -110,7 +110,7 @@ def to_playlist(
     if ref is None or as_ref:
         return ref
 
-    web_tracks = web_playlist.get("tracks", {}).get("items", [])
+    web_tracks = web_playlist.get("tracks", {}).get("items") or []
     if as_items and not isinstance(web_tracks, list):
         return
 


### PR DESCRIPTION
For reason Spotify started returning `null` for some playlists rather than an empty list. This fixes that.