### PR TITLE
Fix floats in API response (Fixes #375)

### DIFF
--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -236,6 +236,11 @@ def web_to_album(web_album):
     return models.Album(uri=ref.uri, name=name, artists=artists)
 
 
+def int_or_none(inp):
+    if inp is not None:
+        return int(float(inp))
+
+
 def web_to_track(web_track, bitrate=None, album=None):
     ref = web_to_track_ref(web_track)
     if ref is None:
@@ -254,8 +259,8 @@ def web_to_track(web_track, bitrate=None, album=None):
         name=ref.name,
         artists=artists,
         album=album,
-        length=web_track.get("duration_ms"),
-        disc_no=web_track.get("disc_number"),
-        track_no=web_track.get("track_number"),
+        length=int_or_none(web_track.get("duration_ms")),
+        disc_no=int_or_none(web_track.get("disc_number")),
+        track_no=int_or_none(web_track.get("track_number")),
         bitrate=bitrate,
     )

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -683,3 +683,29 @@ class TestWebToTrack:
 
         assert track.name == "ABC 123"
         assert track.album is None
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            (123),
+            (123.0),
+            ("123"),
+            ("123.0"),
+        ],
+    )
+    def test_int_or_none_number(self, data):
+        assert translator.int_or_none(data) == 123
+
+    def test_int_or_none_none(self):
+        assert translator.int_or_none(None) is None
+
+    def test_ints_might_be_floats(self, web_track_mock):
+        web_track_mock["duration_ms"] = 123.0
+        web_track_mock["disc_number"] = "456.0"
+        web_track_mock["track_number"] = 99.9
+
+        track = translator.web_to_track(web_track_mock)
+
+        assert track.length == 123
+        assert track.disc_no == 456
+        assert track.track_no == 99


### PR DESCRIPTION
Weirdly Spotify API has started returning floats instead of ints. Let's just handle it.