### PR TITLE
Fix startup time

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,16 @@
+import threading
+
+
+class ThreadJoiner:
+    def __init__(self, timeout: int):
+        self.timeout = timeout
+
+    def __enter__(self):
+        self.before = set(threading.enumerate())
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        new_threads = set(threading.enumerate()) - self.before
+        for thread in new_threads:
+            thread.join(timeout=self.timeout)
+            if thread.is_alive():
+                raise RuntimeError(f"Timeout joining thread {thread}")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@ import threading
 
 
 class ThreadJoiner:
-    def __init__(self, timeout: int):
+    def __init__(self, timeout: int = 1):
         self.timeout = timeout
 
     def __enter__(self):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -4,6 +4,8 @@ from mopidy import backend as backend_api
 from mopidy_spotify import backend, library, playlists
 from mopidy_spotify.backend import SpotifyPlaybackProvider
 
+from tests import ThreadJoiner
+
 
 def get_backend(config):
     obj = backend.SpotifyBackend(config=config, audio=None)
@@ -58,7 +60,8 @@ def test_on_start_configures_proxy(web_mock, config):
         "password": "s3cret",
     }
     backend = get_backend(config)
-    backend.on_start()
+    with ThreadJoiner(timeout=1.0):
+        backend.on_start()
 
     assert True
 
@@ -74,7 +77,8 @@ def test_on_start_configures_web_client(web_mock, config):
     config["spotify"]["client_secret"] = "AbCdEfG"
 
     backend = get_backend(config)
-    backend.on_start()
+    with ThreadJoiner(timeout=1.0):
+        backend.on_start()
 
     web_mock.SpotifyOAuthClient.assert_called_once_with(
         client_id="1234567",
@@ -92,7 +96,8 @@ def test_on_start_logs_in(web_mock, config):
 
 def test_on_start_refreshes_playlists(web_mock, config, caplog):
     backend = get_backend(config)
-    backend.on_start()
+    with ThreadJoiner(timeout=1.0):
+        backend.on_start()
 
     client_mock = web_mock.SpotifyOAuthClient.return_value
     client_mock.get_user_playlists.assert_called_once()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -60,7 +60,7 @@ def test_on_start_configures_proxy(web_mock, config):
         "password": "s3cret",
     }
     backend = get_backend(config)
-    with ThreadJoiner(timeout=1.0):
+    with ThreadJoiner():
         backend.on_start()
 
     assert True
@@ -77,7 +77,7 @@ def test_on_start_configures_web_client(web_mock, config):
     config["spotify"]["client_secret"] = "AbCdEfG"
 
     backend = get_backend(config)
-    with ThreadJoiner(timeout=1.0):
+    with ThreadJoiner():
         backend.on_start()
 
     web_mock.SpotifyOAuthClient.assert_called_once_with(
@@ -96,13 +96,13 @@ def test_on_start_logs_in(web_mock, config):
 
 def test_on_start_refreshes_playlists(web_mock, config, caplog):
     backend = get_backend(config)
-    with ThreadJoiner(timeout=1.0):
+    with ThreadJoiner():
         backend.on_start()
 
     client_mock = web_mock.SpotifyOAuthClient.return_value
-    client_mock.get_user_playlists.assert_called_once()
+    client_mock.get_user_playlists.assert_called_once_with(refresh=True)
+    assert "Refreshing 0 Spotify playlists in background" in caplog.text
     assert "Refreshed 0 Spotify playlists" in caplog.text
-    assert backend.playlists._loaded
 
 
 def test_on_start_doesnt_refresh_playlists_if_not_allowed(web_mock, config, caplog):

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -5,6 +5,8 @@ from mopidy import backend as backend_api
 from mopidy.models import Ref
 from mopidy_spotify import playlists
 
+from tests import ThreadJoiner
+
 
 @pytest.fixture()
 def web_client_mock(web_client_mock, web_track_mock):
@@ -139,7 +141,8 @@ def test_get_items_when_playlist_is_unknown(provider, caplog):
 
 
 def test_refresh_loads_all_playlists(provider, web_client_mock):
-    provider.refresh()
+    with ThreadJoiner(timeout=1.0):
+        provider.refresh()
 
     web_client_mock.get_user_playlists.assert_called_once()
     assert web_client_mock.get_playlist.call_count == 2
@@ -154,7 +157,8 @@ def test_refresh_when_not_logged_in(provider, web_client_mock):
     provider._loaded = False
     web_client_mock.logged_in = False
 
-    provider.refresh()
+    with ThreadJoiner(timeout=1.0):
+        provider.refresh()
 
     web_client_mock.get_user_playlists.assert_not_called()
     web_client_mock.get_playlist.assert_not_called()
@@ -164,7 +168,8 @@ def test_refresh_when_not_logged_in(provider, web_client_mock):
 def test_refresh_sets_loaded(provider, web_client_mock):
     provider._loaded = False
 
-    provider.refresh()
+    with ThreadJoiner(timeout=1.0):
+        provider.refresh()
 
     web_client_mock.get_user_playlists.assert_called_once()
     web_client_mock.get_playlist.assert_called()
@@ -172,13 +177,15 @@ def test_refresh_sets_loaded(provider, web_client_mock):
 
 
 def test_refresh_counts_playlists(provider, caplog):
-    provider.refresh()
+    with ThreadJoiner(timeout=1.0):
+        provider.refresh()
 
     assert "Refreshed 2 Spotify playlists" in caplog.text
 
 
 def test_refresh_clears_caches(provider, web_client_mock):
-    provider.refresh()
+    with ThreadJoiner(timeout=1.0):
+        provider.refresh()
 
     web_client_mock.clear_cache.assert_called_once()
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -49,20 +49,33 @@ def skip_refresh_token():
     patcher.stop()
 
 
+def test_should_refresh_token_requires_lock(oauth_client):
+    with pytest.raises(web.OAuthTokenRefreshError):
+        oauth_client._should_refresh_token()
+
+
+def test_refresh_token_requires_lock(oauth_client):
+    with pytest.raises(web.OAuthTokenRefreshError):
+        oauth_client._refresh_token()
+
+
 def test_initial_refresh_token(oauth_client):
-    assert oauth_client._should_refresh_token()
+    with oauth_client._refresh_mutex:
+        assert oauth_client._should_refresh_token()
 
 
 def test_expired_refresh_token(oauth_client, mock_time):
     oauth_client._expires = 1060
     mock_time.return_value = 1001
-    assert oauth_client._should_refresh_token()
+    with oauth_client._refresh_mutex:
+        assert oauth_client._should_refresh_token()
 
 
 def test_still_valid_refresh_token(oauth_client, mock_time):
     oauth_client._expires = 1060
     mock_time.return_value = 1000
-    assert not oauth_client._should_refresh_token()
+    with oauth_client._refresh_mutex:
+        assert not oauth_client._should_refresh_token()
 
 
 def test_user_agent(oauth_client):
@@ -347,7 +360,7 @@ def test_web_response_status_unchanged_from_cache():
 
     assert not response.status_unchanged
 
-    response.still_valid(ignore_expiry=True)
+    response.still_valid(expiry_strategy=web.ExpiryStrategy.FORCE_FRESH)
 
     assert response.status_unchanged
 
@@ -499,8 +512,20 @@ def test_cache_response_expired(
     assert result["uri"] == "new"
 
 
+def test_cache_response_still_valid_strategy(mock_time):
+    response = web.WebResponse("foo", {}, expires=9999 + 1)
+    mock_time.return_value = 9999
+
+    assert response.still_valid() is True
+    assert response.still_valid(expiry_strategy=None) is True
+    assert response.still_valid(expiry_strategy=web.ExpiryStrategy.FORCE_FRESH) is True
+    assert (
+        response.still_valid(expiry_strategy=web.ExpiryStrategy.FORCE_EXPIRED) is False
+    )
+
+
 @responses.activate
-def test_cache_response_ignore_expiry(
+def test_cache_response_force_fresh(
     web_response_mock, skip_refresh_token, oauth_client, mock_time, caplog
 ):
     cache = {"https://api.spotify.com/v1/tracks/abc": web_response_mock}
@@ -512,11 +537,15 @@ def test_cache_response_ignore_expiry(
     mock_time.return_value = 9999
 
     assert not web_response_mock.still_valid()
-    assert web_response_mock.still_valid(ignore_expiry=True)
-    assert "Cached data forced for" in caplog.text
+    assert "Cached data expired for" in caplog.text
+
+    assert web_response_mock.still_valid(expiry_strategy=web.ExpiryStrategy.FORCE_FRESH)
+    assert "Cached data force-fresh for" in caplog.text
 
     result = oauth_client.get(
-        "https://api.spotify.com/v1/tracks/abc", cache, ignore_expiry=True
+        "https://api.spotify.com/v1/tracks/abc",
+        cache,
+        expiry_strategy=web.ExpiryStrategy.FORCE_FRESH,
     )
     assert len(responses.calls) == 0
     assert result["uri"] == "spotify:track:abc"
@@ -928,6 +957,25 @@ class TestSpotifyOAuthClient:
         assert len(responses.calls) == 1
         assert len(result) == 0
 
+    @pytest.mark.parametrize(
+        ("refresh", "strategy"),
+        [
+            (True, web.ExpiryStrategy.FORCE_EXPIRED),
+            (False, None),
+        ],
+    )
+    def test_get_user_playlists_get_all(self, spotify_client, refresh, strategy):
+        spotify_client.get_all = mock.Mock(return_value=[])
+
+        result = list(spotify_client.get_user_playlists(refresh=refresh))
+
+        spotify_client.get_all.assert_called_once_with(
+            "users/alice/playlists",
+            params={"limit": 50},
+            expiry_strategy=strategy,
+        )
+        assert len(result) == 0
+
     @responses.activate
     def test_get_user_playlists_sets_params(self, spotify_client):
         responses.add(responses.GET, url("users/alice/playlists"), json={})
@@ -1130,13 +1178,6 @@ class TestSpotifyOAuthClient:
     def test_get_playlist_error_msg(self, spotify_client, caplog, uri, msg):
         assert spotify_client.get_playlist(uri) == {}
         assert f"Could not parse {uri!r} as a {msg} URI" in caplog.text
-
-    def test_clear_cache(self, spotify_client):
-        spotify_client._cache = {"foo": "bar"}
-
-        spotify_client.clear_cache()
-
-        assert {} == spotify_client._cache
 
     @pytest.mark.parametrize(("user_id", "expected"), [("alice", True), (None, False)])
     def test_logged_in(self, spotify_client, user_id, expected):


### PR DESCRIPTION
I think this is the best of both worlds since it gets the playlist names immediately, avoids blocking Mopidy startup, but still gathers the track info in the background to make everything snappy later on. 