### PR TITLE
Performance improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-	"mopidy >= 3.4.0",
+	"mopidy >= 4.0.0a1",
 	"pykka >= 4.0",
 	"requests >= 2.20.0",
 	"setuptools >= 66",

--- a/src/mopidy_spotify/browse.py
+++ b/src/mopidy_spotify/browse.py
@@ -108,9 +108,10 @@ def _browse_album(web_client, uri):
         logger.info(f"Failed to browse {uri!r}: {exc}")
         return []
 
-    web_album = web_client.get_album(link)
-    web_tracks = web_album.get("tracks", {}).get("items", [])
-    return list(translator.web_to_track_refs(web_tracks))
+    for web_album in web_client.get_albums([link]):
+        web_tracks = web_album.get("tracks", {}).get("items", [])
+        return list(translator.web_to_track_refs(web_tracks))
+    return []
 
 
 def _browse_artist(web_client, uri):

--- a/src/mopidy_spotify/images.py
+++ b/src/mopidy_spotify/images.py
@@ -1,12 +1,17 @@
-import itertools
 import logging
-import operator
-import urllib.parse
 
 from mopidy_spotify.browse import BROWSE_DIR_URIS
 from mopidy_spotify.translator import web_to_image
+from mopidy_spotify.utils import group_by_type
+from mopidy_spotify.web import LinkType, WebLink
 
 _API_MAX_IDS_PER_REQUEST = 50
+SUPPORTED_TYPES = (
+    LinkType.TRACK,
+    LinkType.ALBUM,
+    LinkType.ARTIST,
+    LinkType.PLAYLIST,
+)
 
 _cache = {}  # (type, id) -> [Image(), ...]
 
@@ -15,85 +20,65 @@ logger = logging.getLogger(__name__)
 
 def get_images(web_client, uris):
     result = {}
-    uri_type_getter = operator.itemgetter("type")
-    uris = (_parse_uri(u) for u in uris)
-    uris = sorted((u for u in uris if u), key=uri_type_getter)
-    for uri_type, group in itertools.groupby(uris, uri_type_getter):
+    links = (_parse_uri(u) for u in uris)
+    for link_type, link_group in group_by_type(links):
         batch = []
-        for uri in group:
-            if uri["key"] in _cache:
-                result[uri["uri"]] = _cache[uri["key"]]
-            elif uri_type == "playlist":
-                result.update(_process_uri(web_client, uri))
+        for link in link_group:
+            key = _make_cache_key(link)
+            if key in _cache:
+                result[link.uri] = _cache[key]
+            elif link_type == LinkType.PLAYLIST:
+                result.update(_process_one(web_client, link))
             else:
-                batch.append(uri)
+                batch.append(link)
                 if len(batch) >= _API_MAX_IDS_PER_REQUEST:
-                    result.update(_process_uris(web_client, uri_type, batch))
+                    result.update(_process_many(web_client, link_type, batch))
                     batch = []
-        result.update(_process_uris(web_client, uri_type, batch))
+        result.update(_process_many(web_client, link_type, batch))
     return result
+
+
+def _make_cache_key(link):
+    return (link.type, link.id)
 
 
 def _parse_uri(uri):
     if uri in BROWSE_DIR_URIS:
         return None  # These are internal to the extension.
     try:
-        parsed_uri = urllib.parse.urlparse(uri)
-        uri_type, uri_id = None, None
-
-        match parsed_uri.scheme:
-            case "spotify":
-                match parsed_uri.path.split(":"):
-                    case uri_type, uri_id, *_:
-                        pass
-                    case _:
-                        raise ValueError("Too few arguments")  # noqa: TRY301
-            case "http" | "https":
-                if parsed_uri.netloc in ("open.spotify.com", "play.spotify.com"):
-                    uri_type, uri_id = parsed_uri.path.split("/")[1:3]
-
-        supported_types = ("track", "album", "artist", "playlist")
-        if uri_type:
-            if uri_type not in supported_types:
-                logger.warning(f"Unsupported image type '{uri_type}' in {uri!r}")
-                return None
-            if uri_id:
-                return {
-                    "uri": uri,
-                    "type": uri_type,
-                    "id": uri_id,
-                    "key": (uri_type, uri_id),
-                }
-        raise ValueError("Unknown error")  # noqa: TRY301
+        link = WebLink.from_uri(uri)
+        if link.type not in SUPPORTED_TYPES:
+            raise ValueError(f"Unsupported image type '{link.type}' in {uri!r}")  # noqa: TRY301
+        if not link.id:
+            raise ValueError("ID missing")  # noqa: TRY301
     except Exception as e:
         logger.exception(f"Could not parse {uri!r} as a Spotify URI ({e!s})")  # noqa: TRY401
+        return None
+
+    return link
 
 
-def _process_uri(web_client, uri):
-    data = web_client.get(f"{uri['type']}s/{uri['id']}")
-    _cache[uri["key"]] = tuple(web_to_image(i) for i in data.get("images") or [])
-    return {uri["uri"]: _cache[uri["key"]]}
+def _process_one(web_client, link):
+    data = web_client.get(f"{link.type}s/{link.id}")
+    key = _make_cache_key(link)
+    _cache[key] = tuple(web_to_image(i) for i in data.get("images") or [])
+    return {link.uri: _cache[key]}
 
 
-def _process_uris(  # noqa: C901
+def _process_many(  # noqa: C901
     web_client,
-    uri_type,
-    uris,
+    link_type,
+    links,
 ):
     result = {}
-    ids = [u["id"] for u in uris]
-    ids_to_uris = {u["id"]: u for u in uris}
-
-    if not uris:
+    if not links:
         return result
 
-    data = web_client.get(uri_type + "s", params={"ids": ",".join(ids)})
-    for item in (
-        data.get(
-            uri_type + "s",
-        )
-        or []
-    ):
+    ids = [u.id for u in links]
+    ids_to_links = {u.id: u for u in links}
+
+    data = web_client.get(link_type + "s", params={"ids": ",".join(ids)})
+    for item in data.get(link_type + "s") or []:
         if not item:
             continue
 
@@ -101,27 +86,26 @@ def _process_uris(  # noqa: C901
             item_id = item["linked_from"].get("id")
         else:
             item_id = item.get("id")
-        uri = ids_to_uris.get(item_id)
-        if not uri:
+        link = ids_to_links.get(item_id)
+        if not link:
             continue
 
-        if uri["key"] not in _cache:
-            if uri_type == "track":
+        key = _make_cache_key(link)
+        if key not in _cache:
+            if link_type == LinkType.TRACK:
                 if "album" not in item:
                     continue
-                album = _parse_uri(item["album"].get("uri"))
-                if not album:
+                album_link = _parse_uri(item["album"].get("uri"))
+                if not album_link:
                     continue
-                album_key = album["key"]
+                album_key = _make_cache_key(album_link)
                 if album_key not in _cache:
                     _cache[album_key] = tuple(
                         web_to_image(i) for i in item["album"].get("images") or []
                     )
-                _cache[uri["key"]] = _cache[album_key]
+                _cache[key] = _cache[album_key]
             else:
-                _cache[uri["key"]] = tuple(
-                    web_to_image(i) for i in item.get("images") or []
-                )
-        result[uri["uri"]] = _cache[uri["key"]]
+                _cache[key] = tuple(web_to_image(i) for i in item.get("images") or [])
+        result[link.uri] = _cache[key]
 
     return result

--- a/src/mopidy_spotify/library.py
+++ b/src/mopidy_spotify/library.py
@@ -34,8 +34,8 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
     def get_images(self, uris):
         return images.get_images(self._backend._web_client, uris)
 
-    def lookup(self, uri):
-        return lookup.lookup(self._config, self._backend._web_client, uri)
+    def lookup_many(self, uris):
+        return lookup.lookup(self._config, self._backend._web_client, uris)
 
     def search(
         self,

--- a/src/mopidy_spotify/lookup.py
+++ b/src/mopidy_spotify/lookup.py
@@ -1,70 +1,95 @@
 import logging
 
-from mopidy_spotify import browse, playlists, translator, utils
-from mopidy_spotify.web import LinkType, WebError, WebLink
+from mopidy_spotify import browse, playlists, translator
+from mopidy_spotify.utils import group_by_type
+from mopidy_spotify.web import LinkType, WebLink
 
 logger = logging.getLogger(__name__)
 
 _VARIOUS_ARTISTS_URI = "spotify:artist:0LyfQWJT6nXafLPZqxe9Of"
 
+# Only for tracks and albums where the result doesn't change.
+_cache = {}  # (type, id) -> [Track(), ...]
 
-def lookup(  # noqa: PLR0911
+
+def lookup(
     config,
     web_client,
-    uri,
+    uris,
 ):
     if web_client is None or not web_client.logged_in:
-        return []
+        logger.error("Not logged in")
+        return {}
 
+    result = {}
+    links = (_parse_uri(u) for u in uris)
+    for link_type, link_group in group_by_type(links):
+        batch = []
+        for link in link_group:
+            key = _make_cache_key(link)
+            if cached_tracks := _cache.get(key):
+                result[link.uri] = cached_tracks
+            elif link_type == LinkType.PLAYLIST:
+                result.update(_lookup_playlist(config, web_client, link))
+            elif link_type == LinkType.YOUR:
+                result.update(_lookup_your(config, web_client, link))
+            elif link_type == LinkType.ARTIST:
+                result.update(_lookup_artist(config, web_client, link))
+            elif link_type in (LinkType.TRACK, LinkType.ALBUM):
+                batch.append(link)
+            else:
+                logger.error(f"Cannot lookup {link_type!r} uri(s)")
+                break
+        if batch:
+            result.update(_lookup_batch(config, web_client, link_type, batch))
+    return result
+
+
+def _make_cache_key(link):
+    return (link.type, link.id)
+
+
+def _cache_tracks(link, tracks):
+    if not tracks or not link:
+        return None
+
+    for t in tracks:
+        track_key = _make_cache_key(_parse_uri(t.uri))
+        _cache[track_key] = [t]
+
+    if link.type not in (LinkType.TRACK, LinkType.ALBUM):
+        return None
+    key = _make_cache_key(link)
+    _cache[key] = tracks
+    return key
+
+
+def _parse_uri(uri):
     try:
-        link = WebLink.from_uri(uri)
+        return WebLink.from_uri(uri)
     except ValueError as exc:
-        logger.info(f"Failed to lookup {uri!r}: {exc}")
-        return []
-
-    try:
-        match link.type:
-            case LinkType.PLAYLIST:
-                return _lookup_playlist(config, web_client, link)
-            case LinkType.YOUR:
-                return list(_lookup_your(config, web_client, link))
-            case LinkType.TRACK:
-                return list(_lookup_track(config, web_client, link))
-            case LinkType.ALBUM:
-                return list(_lookup_album(config, web_client, link))
-            case LinkType.ARTIST:
-                with utils.time_logger("Artist lookup"):
-                    return list(_lookup_artist(config, web_client, link))
-            case _:
-                logger.info(f"Failed to lookup {uri!r}: Cannot handle {link.type!r}")
-                return []
-    except WebError as exc:
-        logger.info(f"Failed to lookup Spotify {link.type.value} {link.uri!r}: {exc}")
-        return []
+        logger.info(exc)
+    return None
 
 
-def _lookup_track(config, web_client, link):
-    web_track = web_client.get_track(link)
-
-    if web_track == {}:
-        raise WebError("Invalid track response")
-
-    track = translator.web_to_track(web_track, bitrate=config["bitrate"])
-    if track is not None:
-        yield track
-
-
-def _lookup_album(config, web_client, link):
-    web_album = web_client.get_album(link)
-    if web_album == {}:
-        raise WebError("Invalid album response")
-
-    yield from translator.web_to_album_tracks(web_album, bitrate=config["bitrate"])
+def _lookup_batch(config, web_client, link_type, links):
+    bitrate = config["bitrate"]
+    for link, item in web_client.get_batch(link_type, links):
+        results = []
+        if link_type == LinkType.TRACK:
+            if (track := translator.web_to_track(item, bitrate=bitrate)) is not None:
+                results = [track]
+            else:
+                logger.info(f"Track '{link.uri}' not found")
+        else:
+            results = translator.web_to_album_tracks(item, bitrate=bitrate)
+        _cache_tracks(link, results)
+        yield link.uri, results
 
 
 def _lookup_artist(config, web_client, link):
-    web_albums = web_client.get_artist_albums(link)
-    for web_album in web_albums:
+    results = []
+    for web_album in web_client.get_artist_albums(link):
         is_various_artists = False
         if web_album.get("album_type", "") == "compilation":
             continue
@@ -74,7 +99,13 @@ def _lookup_artist(config, web_client, link):
                 break
         if is_various_artists:
             continue
-        yield from translator.web_to_album_tracks(web_album, bitrate=config["bitrate"])
+        album_tracks = translator.web_to_album_tracks(
+            web_album, bitrate=config["bitrate"]
+        )
+        album_link = _parse_uri(web_album.get("uri"))
+        _cache_tracks(album_link, album_tracks)
+        results += album_tracks
+    return {link.uri: results}
 
 
 def _lookup_playlist(config, web_client, link):
@@ -84,16 +115,23 @@ def _lookup_playlist(config, web_client, link):
         bitrate=config["bitrate"],
     )
     if playlist is None:
-        raise WebError("Invalid playlist response")
-    return playlist.tracks
+        logger.error(f"Playlist '{link.uri}' not found")
+        return {}
+    _cache_tracks(link, playlist.tracks)
+    return {link.uri: playlist.tracks}
 
 
 def _lookup_your(config, web_client, link):
     parts = link.uri.replace("spotify:your:", "").split(":")
     if len(parts) != 1:
-        return
+        logger.error(f"Your URI '{link.uri}' is not supported.")
+        return {}
     variant = parts[0]
+    if variant not in {"tracks", "albums"}:
+        logger.error(f"Your type '{variant}' is not supported.")
+        return {}
 
+    results = []
     items = browse._load_your_music(web_client, variant)
     if variant == "tracks":
         for item in items:
@@ -101,14 +139,17 @@ def _lookup_your(config, web_client, link):
             web_track = item.get("track", item)
             track = translator.web_to_track(web_track, bitrate=config["bitrate"])
             if track is not None:
-                yield track
+                _cache_tracks(_parse_uri(track.uri), [track])
+                results.append(track)
     elif variant == "albums":
+        album_uris = []
         for item in items:
             # The extra level here is to also support "saved album objects".
             web_album = item.get("album", item)
-            album_ref = translator.web_to_album_ref(web_album)
-            if album_ref is None:
+            if (album_ref := translator.web_to_album_ref(web_album)) is None:
                 continue
-            web_link = WebLink.from_uri(album_ref.uri)
-            if web_link.type == LinkType.ALBUM:
-                yield from _lookup_album(config, web_client, web_link)
+            album_uris.append(album_ref.uri)
+        album_results = lookup(config, web_client, album_uris)
+        for u in album_uris:
+            results += album_results.get(u, [])
+    return {link.uri: results}

--- a/src/mopidy_spotify/playlists.py
+++ b/src/mopidy_spotify/playlists.py
@@ -102,7 +102,7 @@ def playlist_lookup(
     logger.debug(f'Fetching Spotify playlist "{uri!r}"')
     web_playlist = web_client.get_playlist(uri)
 
-    if web_playlist == {}:
+    if not web_playlist:
         logger.error(f"Failed to lookup Spotify playlist URI {uri!r}")
         return None
 

--- a/src/mopidy_spotify/search.py
+++ b/src/mopidy_spotify/search.py
@@ -101,9 +101,10 @@ def search(  # noqa: PLR0913
 
 
 def _search_by_uri(config, web_client, query):
+    results = lookup.lookup(config, web_client, query["uri"])
     tracks = []
     for uri in query["uri"]:
-        tracks += lookup.lookup(config, web_client, uri)
+        tracks += results.get(uri, [])
 
     uri = "spotify:search"
     if len(query["uri"]) == 1:

--- a/src/mopidy_spotify/utils.py
+++ b/src/mopidy_spotify/utils.py
@@ -1,5 +1,7 @@
 import contextlib
+import itertools
 import logging
+import operator
 import time
 
 import requests
@@ -33,3 +35,9 @@ def time_logger(name, level=TRACE):
 
 def flatten(list_of_lists):
     return [item for sublist in list_of_lists for item in sublist]
+
+
+def group_by_type(links):
+    link_type_getter = operator.attrgetter("type")
+    links = sorted((u for u in links if u), key=link_type_getter)
+    return itertools.groupby(links, link_type_getter)

--- a/src/mopidy_spotify/utils.py
+++ b/src/mopidy_spotify/utils.py
@@ -40,4 +40,16 @@ def flatten(list_of_lists):
 def group_by_type(links):
     link_type_getter = operator.attrgetter("type")
     links = sorted((u for u in links if u), key=link_type_getter)
-    return itertools.groupby(links, link_type_getter)
+    yield from itertools.groupby(links, link_type_getter)
+
+
+def batched(iterable, n):
+    """
+    Split into chunks of size n.
+    batched('ABCDEFG', 3) → ABC DEF G
+    """
+    if n < 1:
+        raise ValueError("n must be at least one")
+    it = iter(iterable)
+    while batch := tuple(itertools.islice(it, n)):
+        yield batch

--- a/src/mopidy_spotify/web.py
+++ b/src/mopidy_spotify/web.py
@@ -8,7 +8,7 @@ import urllib.parse
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
-from enum import Enum, unique
+from enum import StrEnum, auto, unique
 from http import HTTPStatus
 
 import requests
@@ -271,7 +271,7 @@ class OAuthClient:
 
 
 @unique
-class ExpiryStrategy(Enum):
+class ExpiryStrategy(StrEnum):
     FORCE_FRESH = "force-fresh"
     FORCE_EXPIRED = "force-expired"
 
@@ -554,12 +554,12 @@ class SpotifyOAuthClient(OAuthClient):
 
 
 @unique
-class LinkType(Enum):
-    TRACK = "track"
-    ALBUM = "album"
-    ARTIST = "artist"
-    PLAYLIST = "playlist"
-    YOUR = "your"
+class LinkType(StrEnum):
+    TRACK = auto()
+    ALBUM = auto()
+    ARTIST = auto()
+    PLAYLIST = auto()
+    YOUR = auto()
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,16 @@ def web_track_mock(web_track_mock_base, web_album_mock_base):
 
 
 @pytest.fixture()
+def web_track_mock_link(web_track_mock):
+    return web.WebLink.from_uri(web_track_mock["uri"])
+
+
+@pytest.fixture()
+def web_album_mock_link(web_album_mock):
+    return web.WebLink.from_uri(web_album_mock["uri"])
+
+
+@pytest.fixture()
 def web_response_mock(web_track_mock):
     return web.WebResponse(
         "https://api.spotify.com/v1/tracks/abc",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,7 @@ def web_track_mock_base(web_artist_mock):
         "name": "ABC 123",
         "track_number": 7,
         "uri": "spotify:track:abc",
+        "id": "abc",
         "type": "track",
         "is_playable": True,
     }
@@ -87,6 +88,7 @@ def web_album_mock_base(web_artist_mock):
     return {
         "name": "DEF 456",
         "uri": "spotify:album:def",
+        "id": "def",
         "type": "album",
         "album_type": "album",
         "artists": [web_artist_mock],
@@ -107,6 +109,7 @@ def web_album_mock_base2(web_artist_mock):
     return {
         "name": "XYZ 789",
         "uri": "spotify:album:xyz",
+        "id": "xyz",
         "type": "album",
         "album_type": "album",
         "artists": [web_artist_mock],

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -106,7 +106,7 @@ def test_browse_item_when_offline(web_client_mock, uri, provider, caplog):
 
 
 def test_browse_album(web_client_mock, web_album_mock, provider):
-    web_client_mock.get_album.return_value = web_album_mock
+    web_client_mock.get_albums.return_value = [web_album_mock]
 
     results = provider.browse("spotify:album:def")
 
@@ -115,7 +115,7 @@ def test_browse_album(web_client_mock, web_album_mock, provider):
 
 
 def test_browse_album_bad_uri(web_client_mock, web_album_mock, provider, caplog):
-    web_client_mock.get_album.return_value = web_album_mock
+    web_client_mock.get_albums.return_value = [web_album_mock]
 
     results = provider.browse("spotify:album:def:xyz")
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,6 +1,7 @@
 import pytest
 from mopidy import models
 from mopidy_spotify import images
+from mopidy_spotify.web import LinkType, WebLink
 
 
 @pytest.fixture()
@@ -10,13 +11,15 @@ def img_provider(provider):
 
 
 def test_get_artist_images(web_client_mock, img_provider):
-    uris = [
-        "spotify:artist:4FCGgZrVQtcbDFEap3OAb2",
-        "http://open.spotify.com/artist/0Nsz79ZcE8E4i3XZhCzZ1l",
+    links = [
+        WebLink.from_uri("spotify:artist:4FCGgZrVQtcbDFEap3OAb2"),
+        WebLink.from_uri("http://open.spotify.com/artist/0Nsz79ZcE8E4i3XZhCzZ1l"),
     ]
+    uris = [link.uri for link in links]
 
-    web_client_mock.get.return_value = {
-        "artists": [
+    web_client_mock.get_batch.return_value = [
+        (
+            links[0],
             {
                 "id": "4FCGgZrVQtcbDFEap3OAb2",
                 "images": [
@@ -24,18 +27,21 @@ def test_get_artist_images(web_client_mock, img_provider):
                     {"height": 300, "url": "img://1/b", "width": 300},
                 ],
             },
+        ),
+        (
+            links[1],
             {
                 "id": "0Nsz79ZcE8E4i3XZhCzZ1l",
                 "images": [{"height": 64, "url": "img://2/a", "width": 64}],
             },
-        ]
-    }
+        ),
+    ]
 
     result = img_provider.get_images(uris)
 
-    web_client_mock.get.assert_called_once_with(
-        "artists",
-        params={"ids": "4FCGgZrVQtcbDFEap3OAb2,0Nsz79ZcE8E4i3XZhCzZ1l"},
+    web_client_mock.get_batch.assert_called_once_with(
+        LinkType.ARTIST,
+        links,
     )
 
     assert len(result) == 2
@@ -64,22 +70,24 @@ def test_get_artist_images(web_client_mock, img_provider):
 
 
 def test_get_album_images(web_client_mock, img_provider):
-    uris = ["http://play.spotify.com/album/1utFPuvgBHXzLJdqhCDOkg"]
+    links = [
+        WebLink.from_uri("http://play.spotify.com/album/1utFPuvgBHXzLJdqhCDOkg"),
+    ]
+    uris = [link.uri for link in links]
 
-    web_client_mock.get.return_value = {
-        "albums": [
+    web_client_mock.get_batch.return_value = [
+        (
+            links[0],
             {
                 "id": "1utFPuvgBHXzLJdqhCDOkg",
                 "images": [{"height": 640, "url": "img://1/a", "width": 640}],
-            }
-        ]
-    }
+            },
+        ),
+    ]
 
     result = img_provider.get_images(uris)
 
-    web_client_mock.get.assert_called_once_with(
-        "albums", params={"ids": "1utFPuvgBHXzLJdqhCDOkg"}
-    )
+    web_client_mock.get_batch.assert_called_once_with(LinkType.ALBUM, links)
 
     assert len(result) == 1
     assert sorted(result.keys()) == sorted(uris)
@@ -93,25 +101,27 @@ def test_get_album_images(web_client_mock, img_provider):
 
 
 def test_get_track_images(web_client_mock, img_provider):
-    uris = ["spotify:track:41shEpOKyyadtG6lDclooa"]
+    links = [
+        WebLink.from_uri("spotify:track:41shEpOKyyadtG6lDclooa"),
+    ]
+    uris = [link.uri for link in links]
 
-    web_client_mock.get.return_value = {
-        "tracks": [
+    web_client_mock.get_batch.return_value = [
+        (
+            links[0],
             {
                 "id": "41shEpOKyyadtG6lDclooa",
                 "album": {
                     "uri": "spotify:album:1utFPuvgBHXzLJdqhCDOkg",
                     "images": [{"height": 640, "url": "img://1/a", "width": 640}],
                 },
-            }
-        ]
-    }
+            },
+        ),
+    ]
 
     result = img_provider.get_images(uris)
 
-    web_client_mock.get.assert_called_once_with(
-        "tracks", params={"ids": "41shEpOKyyadtG6lDclooa"}
-    )
+    web_client_mock.get_batch.assert_called_once_with(LinkType.TRACK, links)
 
     assert len(result) == 1
     assert sorted(result.keys()) == sorted(uris)
@@ -125,31 +135,41 @@ def test_get_track_images(web_client_mock, img_provider):
 
 
 def test_get_track_images_bad_album_uri(web_client_mock, img_provider):
-    uris = ["spotify:track:41shEpOKyyadtG6lDclooa"]
+    links = [
+        WebLink.from_uri("spotify:track:41shEpOKyyadtG6lDclooa"),
+    ]
+    uris = [link.uri for link in links]
 
-    web_client_mock.get.return_value = {
-        "tracks": [
+    web_client_mock.get_batch.return_value = [
+        (
+            links[0],
             {
                 "id": "41shEpOKyyadtG6lDclooa",
                 "album": {
                     "uri": "spotify:bad-data",
                     "images": [{"height": 640, "url": "img://1/a", "width": 640}],
                 },
-            }
-        ]
-    }
+            },
+        ),
+    ]
 
     result = img_provider.get_images(uris)
     assert result == {}
 
+    web_client_mock.get_batch.assert_called_once_with(LinkType.TRACK, links)
+
 
 def test_get_relinked_track_images(web_client_mock, img_provider):
-    uris = ["spotify:track:4nqN0p0FjfH39G3hxeuKad"]
+    links = [
+        WebLink.from_uri("spotify:track:4nqN0p0FjfH39G3hxeuKad"),
+    ]
+    uris = [link.uri for link in links]
 
-    web_client_mock.get.return_value = {
-        "tracks": [
+    web_client_mock.get_batch.return_value = [
+        (
+            links[0],
             {
-                "id": "39S0DVDKeneEjsq4pV45PT",
+                "id": "41shEpOKyyadtG6lDclooa",
                 "linked_from": {
                     "id": "4nqN0p0FjfH39G3hxeuKad",
                     "type": "track",
@@ -159,15 +179,13 @@ def test_get_relinked_track_images(web_client_mock, img_provider):
                     "uri": "spotify:album:1utFPuvgBHXzLJdqhCDOkg",
                     "images": [{"height": 640, "url": "img://1/a", "width": 640}],
                 },
-            }
-        ]
-    }
+            },
+        ),
+    ]
 
     result = img_provider.get_images(uris)
 
-    web_client_mock.get.assert_called_once_with(
-        "tracks", params={"ids": "4nqN0p0FjfH39G3hxeuKad"}
-    )
+    web_client_mock.get_batch.assert_called_once_with(LinkType.TRACK, links)
 
     assert len(result) == 1
     assert sorted(result.keys()) == sorted(uris)
@@ -178,6 +196,32 @@ def test_get_relinked_track_images(web_client_mock, img_provider):
     assert image.uri == "img://1/a"
     assert image.height == 640
     assert image.width == 640
+
+
+def test_get_track_images_cached(web_client_mock, img_provider):
+    links = [
+        WebLink.from_uri("spotify:track:41shEpOKyyadtG6lDclooa"),
+    ]
+    uris = [link.uri for link in links]
+
+    web_client_mock.get_batch.return_value = [
+        (
+            links[0],
+            {
+                "id": "41shEpOKyyadtG6lDclooa",
+                "album": {
+                    "uri": "spotify:album:1utFPuvgBHXzLJdqhCDOkg",
+                    "images": [{"height": 640, "url": "img://1/a", "width": 640}],
+                },
+            },
+        ),
+    ]
+
+    result1 = img_provider.get_images(uris)
+    result2 = img_provider.get_images(uris)
+
+    assert web_client_mock.get_batch.call_count == 1
+    assert result1 == result2
 
 
 def test_get_playlist_image(web_client_mock, img_provider):
@@ -203,19 +247,12 @@ def test_get_playlist_image(web_client_mock, img_provider):
     assert image.width == 640
 
 
-def test_results_are_cached(web_client_mock, img_provider):
-    uris = ["spotify:track:41shEpOKyyadtG6lDclooa"]
+def test_get_playlist_image_cached(web_client_mock, img_provider):
+    uris = ["spotify:playlist:41shEpOKyyadtG6lDclooa"]
 
     web_client_mock.get.return_value = {
-        "tracks": [
-            {
-                "id": "41shEpOKyyadtG6lDclooa",
-                "album": {
-                    "uri": "spotify:album:1utFPuvgBHXzLJdqhCDOkg",
-                    "images": [{"height": 640, "url": "img://1/a", "width": 640}],
-                },
-            }
-        ]
+        "id": "41shEpOKyyadtG6lDclooa",
+        "images": [{"height": 640, "url": "img://1/a", "width": 640}],
     }
 
     result1 = img_provider.get_images(uris)
@@ -225,20 +262,34 @@ def test_results_are_cached(web_client_mock, img_provider):
     assert result1 == result2
 
 
-def test_max_50_ids_per_request(web_client_mock, img_provider):
-    uris = [f"spotify:track:{i}" for i in range(51)]
+@pytest.mark.parametrize(
+    "link_type",
+    [
+        "album",
+        "artist",
+    ],
+)
+def test_results_are_cached(web_client_mock, img_provider, link_type):
+    links = [
+        WebLink.from_uri(f"spotify:{link_type}:41shEpOKyyadtG6lDclooa"),
+    ]
+    uris = [link.uri for link in links]
 
-    web_client_mock.get.return_value = {}
+    web_client_mock.get_batch.return_value = [
+        (
+            links[0],
+            {
+                "id": "41shEpOKyyadtG6lDclooa",
+                "images": [{"height": 640, "url": "img://1/a", "width": 640}],
+            },
+        ),
+    ]
 
-    img_provider.get_images(uris)
+    result1 = img_provider.get_images(uris)
+    result2 = img_provider.get_images(uris)
 
-    assert web_client_mock.get.call_count == 2
-
-    request_ids_1 = web_client_mock.get.call_args_list[0][1]["params"]["ids"]
-    assert request_ids_1 == ",".join(str(i) for i in range(50))
-
-    request_ids_2 = web_client_mock.get.call_args_list[1][1]["params"]["ids"]
-    assert request_ids_2 == "50"
+    assert web_client_mock.get_batch.call_count == 1
+    assert result1 == result2
 
 
 @pytest.mark.parametrize(

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -245,11 +245,9 @@ def test_max_50_ids_per_request(web_client_mock, img_provider):
     "uri",
     [
         "foo:bar",
-        "spotify:baz",
-        "spotify:artist",
-        "spotify:album",
-        "spotify:user",
+        "spotify:user:bob:starred",
         "spotify:playlist",
+        "spotify:your:fish",
     ],
 )
 def test_invalid_uri(img_provider, caplog, uri):
@@ -259,14 +257,11 @@ def test_invalid_uri(img_provider, caplog, uri):
     assert f"Could not parse '{uri}' as a Spotify URI" in caplog.text
 
 
-@pytest.mark.parametrize(
-    "uri", ["spotify:dog:cat", "spotify:your:fish", "spotify:top:hat"]
-)
-def test_unsupported_image_type(img_provider, caplog, uri):
+def test_unsupported_image_type(img_provider, caplog):
     with caplog.at_level(5):
-        result = img_provider.get_images([uri])
+        result = img_provider.get_images(["spotify:your:fish"])
     assert result == {}
-    assert f"Unsupported image type '{uri.split(':')[1]}'" in caplog.text
+    assert "Unsupported image type 'your'" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,84 +1,103 @@
 import copy
+from unittest import mock
+
+import pytest
+from mopidy_spotify import lookup
 
 
-def test_lookup_of_invalid_uri(provider, caplog):
-    results = provider.lookup("invalid")
-
-    assert len(results) == 0
-    assert "Failed to lookup 'invalid': Could not parse" in caplog.text
+@pytest.fixture(autouse=True)
+def clear_cache():
+    return lookup._cache.clear()
 
 
-def test_lookup_of_invalid_playlist_uri(provider, caplog):
-    results = provider.lookup("spotify:playlist")
-
-    assert len(results) == 0
-    assert "Failed to lookup 'spotify:playlist': Could not parse" in caplog.text
-
-
-def test_lookup_of_invalid_track_uri(web_client_mock, provider, caplog):
-    web_client_mock.get_track.return_value = {}
-
-    results = provider.lookup("spotify:track:invalid")
-
-    assert len(results) == 0
-    assert (
-        "Failed to lookup Spotify track 'spotify:track:invalid': Invalid track response"
-        in caplog.text
-    )
-
-
-def test_lookup_of_unhandled_uri(provider, caplog):
-    results = provider.lookup("spotify:invalid:something")
+@pytest.mark.parametrize(
+    "uri,",
+    [
+        ("invalid"),
+        ("spotify:playlist"),
+        ("spotify:invalid:something"),
+        ("spotify:your:tracks:invalid"),
+    ],
+)
+def test_lookup_of_invalid_uri(provider, caplog, uri):
+    results = provider.lookup_many([uri])
 
     assert len(results) == 0
-    assert (
-        "Failed to lookup 'spotify:invalid:something': "
-        "Could not parse 'spotify:invalid:something' as a Spotify URI" in caplog.text
-    )
+    assert f"Could not parse '{uri}' as a Spotify URI" in caplog.text
+
+
+def test_lookup_of_invalid_your_uri(provider, caplog):
+    results = provider.lookup_many(["spotify:your:artists"])
+
+    assert len(results) == 0
+    assert "Your type 'artists' is not supported" in caplog.text
+
+
+def test_lookup_of_unknown_track_uri(
+    web_client_mock, provider, web_track_mock_link, caplog
+):
+    web_client_mock.get_batch.return_value = [(web_track_mock_link, {})]
+
+    results = provider.lookup_many(["spotify:track:abc"])
+
+    web_client_mock.get_batch.assert_called_once()
+    assert len(results) == 1
+    assert len(results["spotify:track:abc"]) == 0
+    assert "Track 'spotify:track:abc' not found" in caplog.text
 
 
 def test_lookup_when_offline(web_client_mock, provider, caplog):
     web_client_mock.logged_in = False
 
-    results = provider.lookup("spotify:invalid:something")
+    results = provider.lookup_many(["spotify:invalid:something"])
 
     assert len(results) == 0
-    assert "Failed to lookup" not in caplog.text
+    assert "Not logged in" in caplog.text
 
 
-def test_lookup_of_track_uri(web_client_mock, web_track_mock, provider):
-    web_client_mock.get_track.return_value = web_track_mock
+def test_lookup_of_track_uri(
+    web_client_mock, web_track_mock, web_track_mock_link, provider
+):
+    web_client_mock.get_batch.return_value = [(web_track_mock_link, web_track_mock)]
 
-    results = provider.lookup("spotify:track:abc")
+    results = provider.lookup_many(["spotify:track:abc"])
 
+    web_client_mock.get_batch.assert_called_once()
     assert len(results) == 1
-    track = results[0]
+    track = results["spotify:track:abc"][0]
     assert track.uri == "spotify:track:abc"
     assert track.name == "ABC 123"
     assert track.bitrate == 160
     assert track.album.name == "DEF 456"
 
 
-def test_lookup_of_album_uri(web_client_mock, web_album_mock, provider):
-    web_client_mock.get_album.return_value = web_album_mock
+def test_lookup_of_album_uri(
+    web_client_mock, web_album_mock, web_album_mock_link, provider
+):
+    web_client_mock.get_batch.return_value = [(web_album_mock_link, web_album_mock)]
 
-    results = provider.lookup("spotify:album:def")
+    results = provider.lookup_many(["spotify:album:def"])
 
-    assert len(results) == 10
-    track = results[0]
+    web_client_mock.get_batch.assert_called_once()
+    assert len(results) == 1
+    assert len(results["spotify:album:def"]) == 10
+    track = results["spotify:album:def"][0]
     assert track.uri == "spotify:track:abc"
     assert track.name == "ABC 123"
     assert track.bitrate == 160
     assert track.album.name == "DEF 456"
 
 
-def test_lookup_of_album_uri_empty_response(web_client_mock, provider, caplog):
-    web_client_mock.get_album.return_value = {}
+def test_lookup_of_album_uri_empty_response(
+    web_client_mock, web_album_mock_link, provider, caplog
+):
+    web_client_mock.get_batch.return_value = [(web_album_mock_link, {})]
 
-    results = provider.lookup("spotify:album:def")
+    results = provider.lookup_many(["spotify:album:def"])
 
-    assert len(results) == 0
-    assert "Invalid album response" in caplog.text
+    web_client_mock.get_batch.assert_called_once()
+    assert len(results) == 1
+    assert len(results["spotify:album:def"]) == 0
 
 
 def test_lookup_of_artist_uri(
@@ -94,17 +113,18 @@ def test_lookup_of_artist_uri(
         web_album_mock,
         web_album_mock2,
     ]
-    results = provider.lookup("spotify:artist:abba")
+    results = provider.lookup_many(["spotify:artist:abba"])
 
-    assert len(results) == 13
+    assert len(results) == 1
+    assert len(results["spotify:artist:abba"]) == 13
 
-    track = results[0]
+    track = results["spotify:artist:abba"][0]
     assert track.uri == "spotify:track:abc"
     assert track.name == "ABC 123"
     assert track.album.name == "DEF 456"
     assert track.bitrate == 160
 
-    track = results[10]
+    track = results["spotify:artist:abba"][10]
     assert track.uri == "spotify:track:abc"
     assert track.name == "XYZ track"
     assert track.album.name == "XYZ album"
@@ -120,9 +140,10 @@ def test_lookup_of_artist_ignores_unavailable_albums(
         web_album_mock2,
     ]
 
-    results = provider.lookup("spotify:artist:abba")
+    results = provider.lookup_many(["spotify:artist:abba"])
 
-    assert len(results) == 2
+    assert len(results) == 1
+    assert len(results["spotify:artist:abba"]) == 2
 
 
 def test_lookup_of_artist_uri_ignores_compilations(
@@ -131,9 +152,10 @@ def test_lookup_of_artist_uri_ignores_compilations(
     web_album_mock["album_type"] = "compilation"
     web_client_mock.get_artist_albums.return_value = [web_album_mock]
 
-    results = provider.lookup("spotify:artist:abba")
+    results = provider.lookup_many(["spotify:artist:abba"])
 
-    assert len(results) == 0
+    assert len(results) == 1
+    assert len(results["spotify:artist:abba"]) == 0
 
 
 def test_lookup_of_artist_uri_ignores_various_artists_albums(
@@ -142,88 +164,161 @@ def test_lookup_of_artist_uri_ignores_various_artists_albums(
     web_album_mock["artists"][0]["uri"] = "spotify:artist:0LyfQWJT6nXafLPZqxe9Of"
     web_client_mock.get_artist_albums.return_value = [web_album_mock]
 
-    results = provider.lookup("spotify:artist:abba")
+    results = provider.lookup_many(["spotify:artist:abba"])
 
-    assert len(results) == 0
+    assert len(results) == 1
+    assert len(results["spotify:artist:abba"]) == 0
 
 
 def test_lookup_of_playlist_uri(web_client_mock, web_playlist_mock, provider):
     web_client_mock.get_playlist.return_value = web_playlist_mock
 
-    results = provider.lookup("spotify:playlist:alice:foo")
+    playlist_uri = web_playlist_mock["uri"]
+    results = provider.lookup_many([playlist_uri])
 
-    web_client_mock.get_playlist.assert_called_once_with("spotify:playlist:alice:foo")
+    web_client_mock.get_playlist.assert_called_once_with(playlist_uri)
 
     assert len(results) == 1
-    track = results[0]
+    track = results[playlist_uri][0]
     assert track.uri == "spotify:track:abc"
     assert track.name == "ABC 123"
     assert track.bitrate == 160
 
 
-def test_lookup_of_playlist_uri_empty_response(web_client_mock, provider, caplog):
+def test_lookup_of_playlist_uri_empty_response(
+    web_client_mock, web_playlist_mock, provider, caplog
+):
     web_client_mock.get_playlist.return_value = None
 
-    results = provider.lookup("spotify:playlist:alice:foo")
+    playlist_uri = web_playlist_mock["uri"]
+    results = provider.lookup_many([playlist_uri])
 
     assert len(results) == 0
-    assert "Invalid playlist response" in caplog.text
+    assert f"Playlist '{playlist_uri}' not found" in caplog.text
 
 
 def test_lookup_of_yourtracks_uri(web_client_mock, web_track_mock, provider):
     web_saved_track_mock = {"track": web_track_mock}
     web_client_mock.get_all.return_value = [
-        {"items": [web_saved_track_mock, web_saved_track_mock]},
+        {"items": [web_track_mock, web_saved_track_mock]},
         {"items": [web_saved_track_mock, web_saved_track_mock]},
     ]
 
-    results = provider.lookup("spotify:your:tracks")
+    results = provider.lookup_many(["spotify:your:tracks"])
 
-    assert len(results) == 4
-    for track in results:
+    web_client_mock.get_all.assert_called_once()
+    assert len(results) == 1
+    assert len(results["spotify:your:tracks"]) == 4
+    for track in results["spotify:your:tracks"]:
         assert track.uri == "spotify:track:abc"
         assert track.name == "ABC 123"
         assert track.bitrate == 160
         assert track.album.name == "DEF 456"
 
+    assert results == provider.lookup_many(["spotify:your:tracks"])
+    assert web_client_mock.get_all.call_count == 2  # Not cached
 
-def test_lookup_of_youralbums_uri(web_client_mock, web_album_mock, provider):
+    results = provider.lookup_many(["spotify:track:abc"])
+    assert len(results["spotify:track:abc"]) == 1
+
+
+def test_lookup_of_youralbums_uri(
+    web_client_mock, web_album_mock, web_album_mock_link, provider
+):
     web_saved_album_mock = {"album": web_album_mock}
     web_client_mock.get_all.return_value = [
-        {"items": [web_saved_album_mock, web_saved_album_mock]},
+        {"items": [web_album_mock, web_saved_album_mock]},
         {"items": [web_saved_album_mock, web_saved_album_mock]},
     ]
-    web_client_mock.get_album.return_value = web_album_mock
+    web_client_mock.get_batch.side_effect = [
+        [(web_album_mock_link, web_album_mock)],
+        [],
+    ]
 
-    results = provider.lookup("spotify:your:albums")
+    results = provider.lookup_many(["spotify:your:albums"])
 
-    assert len(results) == 4 * 10
-    for track in results:
+    web_client_mock.get_all.assert_called_once()
+    web_client_mock.get_batch.assert_called_once()
+    assert len(results) == 1
+    assert len(results["spotify:your:albums"]) == 4 * 10
+    for track in results["spotify:your:albums"]:
         assert track.uri == "spotify:track:abc"
         assert track.name == "ABC 123"
         assert track.album.uri == "spotify:album:def"
         assert track.bitrate == 160
         assert track.album.name == "DEF 456"
 
+    assert results == provider.lookup_many(["spotify:your:albums"])
+    assert web_client_mock.get_all.call_count == 2  # Not cached
+    web_client_mock.get_batch.assert_called_once()  # Cached
 
-def test_lookup_of_your_uri_when_not_logged_in(web_client_mock, provider):
-    web_client_mock.user_id = None
-
-    results = provider.lookup("spotify:your:tracks")
-
-    assert len(results) == 0
-
-
-def test_lookup_of_unhandled_your_uri(provider):
-    results = provider.lookup("spotify:your:artists")
-
-    assert len(results) == 0
+    results = provider.lookup_many(["spotify:album:def"])
+    assert len(results["spotify:album:def"]) == 10
+    web_client_mock.get_batch.assert_called_once()  # Cached
 
 
-def test_lookup_of_invalid_your_uri(provider, caplog):
-    results = provider.lookup("spotify:your:tracks:invalid")
+def test_lookup_caches_tracks_albums(
+    web_client_mock, web_album_mock, web_album_mock_link, provider
+):
+    web_client_mock.get_batch.return_value = [(web_album_mock_link, web_album_mock)]
 
-    assert len(results) == 0
-    assert (
-        "Failed to lookup 'spotify:your:tracks:invalid': Could not parse" in caplog.text
+    results1 = provider.lookup_many(["spotify:album:def"])
+    results2 = provider.lookup_many(["spotify:album:def"])
+    results3 = provider.lookup_many(["spotify:track:abc"])
+
+    web_client_mock.get_batch.assert_called_once()
+    assert len(results1) == 1
+    assert len(results1["spotify:album:def"]) == 10
+    track = results1["spotify:album:def"][0]
+    assert track.uri == "spotify:track:abc"
+
+    assert len(results2) == 1
+    assert len(results2["spotify:album:def"]) == 10
+    track = results2["spotify:album:def"][0]
+    assert track.uri == "spotify:track:abc"
+
+    assert len(results3) == 1
+    assert len(results3["spotify:track:abc"]) == 1
+    track = results3["spotify:track:abc"][0]
+    assert track.uri == "spotify:track:abc"
+
+
+def test_lookup_caches_no_cache_playlist(web_client_mock, web_playlist_mock, provider):
+    web_client_mock.get_playlist.return_value = web_playlist_mock
+
+    playlist_uri = web_playlist_mock["uri"]
+    results1 = provider.lookup_many([playlist_uri])
+    results2 = provider.lookup_many([playlist_uri])
+    results3 = provider.lookup_many(["spotify:track:abc"])
+
+    web_client_mock.get_playlist.assert_has_calls(
+        [mock.call(playlist_uri), mock.call(playlist_uri)]
     )
+    web_client_mock.get_batch.assert_not_called()
+
+    assert len(results1) == 1
+    assert results1[playlist_uri][0].uri == "spotify:track:abc"
+    assert results1 == results2
+
+    assert len(results3) == 1
+    assert results3["spotify:track:abc"][0].uri == "spotify:track:abc"
+
+
+def test_lookup_no_cache_artist(web_client_mock, web_album_mock, provider):
+    web_client_mock.get_artist_albums.return_value = [web_album_mock]
+
+    artist_uri = "spotify:artist:abba"
+    results1 = provider.lookup_many([artist_uri])
+    results2 = provider.lookup_many([artist_uri])
+    results3 = provider.lookup_many(["spotify:album:def", "spotify:track:abc"])
+
+    assert web_client_mock.get_artist_albums.call_count == 2
+    web_client_mock.get_batch.assert_not_called()
+
+    assert len(results1) == 1
+    assert results1[artist_uri][0].uri == "spotify:track:abc"
+    assert results1 == results2
+
+    assert len(results3) == 2
+    assert results3["spotify:album:def"][0].uri == "spotify:track:abc"
+    assert results3["spotify:track:abc"][0].uri == "spotify:track:abc"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import re
+from unittest import mock
 
 from mopidy_spotify import utils
 
@@ -8,3 +9,48 @@ def test_time_logger(caplog):
         pass
 
     assert re.match(r".*task took \d+ms.*", caplog.text)
+
+
+def test_group_by_type():
+    mocks = [mock.Mock(type=i % 3) for i in range(10)]
+
+    types = []
+    groups = []
+    for mock_type, mock_group in utils.group_by_type(mocks):
+        types.append(mock_type)
+        groups.append(list(mock_group))
+
+    assert types == [0, 1, 2]
+    assert groups == [
+        [mocks[0], mocks[3], mocks[6], mocks[9]],
+        [mocks[1], mocks[4], mocks[7]],
+        [mocks[2], mocks[5], mocks[8]],
+    ]
+
+
+def test_group_by_type_sorts():
+    mocks = [
+        mock.Mock(type="foo"),
+        mock.Mock(type="bar"),
+        None,
+        mock.Mock(type="foo"),
+        mock.Mock(type="baz"),
+    ]
+
+    types = []
+    groups = []
+    for mock_type, mock_group in utils.group_by_type(mocks):
+        types.append(mock_type)
+        groups.append(list(mock_group))
+
+    assert types == ["bar", "baz", "foo"]
+    assert groups == [
+        [mocks[1]],
+        [mocks[4]],
+        [mocks[0], mocks[3]],
+    ]
+
+
+def test_batched():
+    result = list(utils.batched("ABCDEFG", 3))
+    assert result == [("A", "B", "C"), ("D", "E", "F"), ("G",)]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1444,10 +1444,16 @@ def test_weblink_from_uri_playlist(uri, id_, owner):
         ("spotify:user:alice:track:foo"),
         ("local:user:alice:playlist:foo"),
         ("spotify:track:foo:bar"),
-        ("spotify:album:"),
         ("https://yahoo.com/playlist/foo"),
         ("https://play.spotify.com/foo"),
         ("total/junk"),
+        ("foo:bar"),
+        ("spotify:baz"),
+        ("spotify:artist"),
+        ("spotify:album"),
+        ("spotify:user"),
+        ("spotify:playlist"),
+        ("spotify:playlist:"),
     ],
 )
 def test_weblink_from_uri_raises(uri):


### PR DESCRIPTION
Using Mopidy's new `lookup_many` to batch track and album requests and cache the resulting Mopidy models. Will eventually move everything to cache at this level, rather than HTTP. 

Sorry for a big horrible merge but it was getting too much effort to untangle it. Rather just have this in and start working on other things.