### PR TITLE
Temporary hack for Mopidy v4 installations

### DIFF
--- a/src/mopidy_spotify/library.py
+++ b/src/mopidy_spotify/library.py
@@ -34,6 +34,9 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
     def get_images(self, uris):
         return images.get_images(self._backend._web_client, uris)
 
+    def lookup(self, uri):
+        return lookup.lookup(self._config, self._backend._web_client, [uri])
+
     def lookup_many(self, uris):
         return lookup.lookup(self._config, self._backend._web_client, uris)
 

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,6 +1,7 @@
 import copy
 from unittest import mock
 
+import mopidy
 import pytest
 from mopidy_spotify import lookup
 
@@ -322,3 +323,9 @@ def test_lookup_no_cache_artist(web_client_mock, web_album_mock, provider):
     assert len(results3) == 2
     assert results3["spotify:album:def"][0].uri == "spotify:track:abc"
     assert results3["spotify:track:abc"][0].uri == "spotify:track:abc"
+
+
+def test_lookup_v4_compatible(provider):
+    # TODO: Remove this once we release the major version
+    provider.lookup("foo")
+    assert mopidy.__version__.startswith("4.0.0a")


### PR DESCRIPTION
This is only a bodge until we do a release and just helps in the cases where people are still installing from git like I originally suggested they did, and so pip brings in the required Mopidy v4 dep but it doesn't actually get used and their mopidy service is still using Mopidy v3 (which doesn't support `lookup_many`.