### PR TITLE
refactor: Update commands to use cyclopts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "mopidy >= 4.0.0a8",
+    "mopidy >= 4.0.0a14",
     "pykka >= 4.1",
     "requests >= 2.32",
 ]

--- a/src/mopidy_spotify/__init__.py
+++ b/src/mopidy_spotify/__init__.py
@@ -52,12 +52,12 @@ class Extension(ext.Extension):
         registry.add("backend", SpotifyBackend)
 
     def get_command(self):
-        from .commands import SpotifyCommand  # noqa: PLC0415
+        from .commands import app  # noqa: PLC0415
 
-        return SpotifyCommand()
+        return app
 
     @classmethod
-    def get_credentials_dir(cls, config):
+    def get_credentials_dir(cls, config) -> pathlib.Path:
         data_dir = cls.get_data_dir(config)
         credentials_dir = data_dir / "credentials-cache"
         credentials_dir.mkdir(mode=0o700, exist_ok=True)

--- a/src/mopidy_spotify/commands.py
+++ b/src/mopidy_spotify/commands.py
@@ -2,41 +2,34 @@ import logging
 import os
 from pathlib import Path
 
-from mopidy import commands
+import cyclopts
+from mopidy.config import Config
 
 from mopidy_spotify import Extension
 
 logger = logging.getLogger(__name__)
 
 
-class SpotifyCommand(commands.Command):
-    def __init__(self):
-        super().__init__()
-        self.add_child("logout", LogoutCommand())
+app = cyclopts.App(help="Spotify extension commands.")
 
 
-class LogoutCommand(commands.Command):
-    help = "Logout from Spotify account."
-
-    def run(
-        self,
-        args,  # noqa: ARG002
-        config,
-    ):
-        credentials_dir = Extension().get_credentials_dir(config)
-        try:
-            for root, dirs, files in os.walk(credentials_dir, topdown=False):
-                root_path = Path(root)
-                for name in files:
-                    file_path = root_path / name
-                    file_path.unlink()
-                    logger.debug(f"Removed file {file_path}")
-                for name in dirs:
-                    dir_path = root_path / name
-                    dir_path.rmdir()
-                    logger.debug(f"Removed directory {dir_path}")
-            credentials_dir.rmdir()
-        except Exception as error:  # noqa: BLE001
-            logger.warning(f"Failed to logout from Spotify: {error}")
-        else:
-            logger.info("Logged out from Spotify")
+@app.command(help="Logout from Spotify account.")
+def logout():
+    config = Config.get_global()
+    credentials_dir = Extension().get_credentials_dir(config)
+    try:
+        for root, dirs, files in os.walk(credentials_dir, topdown=False):
+            root_path = Path(root)
+            for name in files:
+                file_path = root_path / name
+                file_path.unlink()
+                logger.debug(f"Removed file {file_path}")
+            for name in dirs:
+                dir_path = root_path / name
+                dir_path.rmdir()
+                logger.debug(f"Removed directory {dir_path}")
+        credentials_dir.rmdir()
+    except Exception as error:  # noqa: BLE001
+        logger.warning(f"Failed to logout from Spotify: {error}")
+    else:
+        logger.info("Logged out from Spotify")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,16 +1,17 @@
-from unittest.mock import sentinel
+from mopidy.config import Config
 
 from mopidy_spotify import Extension
-from mopidy_spotify.commands import LogoutCommand
+from mopidy_spotify.commands import logout
 
 
 def test_logout_command(tmp_path):
-    config = {"core": {"data_dir": tmp_path}}
+    config = Config({"core": {"data_dir": tmp_path}})
+    Config.set_global(config)
+
     credentials_dir = Extension().get_credentials_dir(config)
     (credentials_dir / "foo").mkdir()
     (credentials_dir / "bar").touch()
 
-    cmd = LogoutCommand()
-    cmd.run(sentinel.args, config)
+    logout()
 
     assert not credentials_dir.is_dir()


### PR DESCRIPTION
Instead of the removed `mopidy.commands` API.