### PR TITLE
chore: Require Mopidy >= 4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "mopidy >= 4.0.0a14",
+    "mopidy >= 4.0.0",
     "pykka >= 4.1",
     "requests >= 2.32",
 ]

--- a/src/mopidy_spotify/library.py
+++ b/src/mopidy_spotify/library.py
@@ -33,9 +33,6 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
     def get_images(self, uris):
         return images.get_images(self._backend._web_client, uris)
 
-    def lookup(self, uri):
-        return lookup.lookup(self._config, self._backend._web_client, [uri])
-
     def lookup_many(self, uris):
         return lookup.lookup(self._config, self._backend._web_client, uris)
 

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,7 +1,6 @@
 import copy
 from unittest import mock
 
-import mopidy
 import pytest
 
 from mopidy_spotify import lookup
@@ -324,9 +323,3 @@ def test_lookup_no_cache_artist(web_client_mock, web_album_mock, provider):
     assert len(results3) == 2
     assert results3["spotify:album:def"][0].uri == "spotify:track:abc"
     assert results3["spotify:track:abc"][0].uri == "spotify:track:abc"
-
-
-def test_lookup_v4_compatible(provider):
-    # TODO: Remove this once we release the major version
-    provider.lookup("foo")
-    assert mopidy.__version__.startswith("4.0.0a")


### PR DESCRIPTION
...and revert workaround for <4.0.