### PR TITLE
fix: version fall back when package metadata is unavailable

### DIFF
--- a/src/mopidy_spotify/__init__.py
+++ b/src/mopidy_spotify/__init__.py
@@ -1,11 +1,14 @@
 import pathlib
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 from typing import override
 
 import cyclopts
 from mopidy import config, ext
 
-__version__ = version("mopidy-spotify")
+try:
+    __version__ = version("mopidy-spotify")
+except PackageNotFoundError:
+    __version__ = "0.0.0+local"
 
 
 class Extension(ext.Extension):


### PR DESCRIPTION
I'm running things with nix these days, which runs without git, which means `version` might fail. In that case it is better to fallback to a dummy version IMO.