### PR TITLE
fix: correct pytest single-arg parametrization

### DIFF
--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -15,12 +15,12 @@ def clear_cache():
 
 
 @pytest.mark.parametrize(
-    "uri,",
+    "uri",
     [
-        ("invalid"),
-        ("spotify:playlist"),
-        ("spotify:invalid:something"),
-        ("spotify:your:tracks:invalid"),
+        "invalid",
+        "spotify:playlist",
+        "spotify:invalid:something",
+        "spotify:your:tracks:invalid",
     ],
 )
 def test_lookup_of_invalid_uri(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1382,10 +1382,7 @@ class TestSpotifyOAuthClient:
         assert "Expecting Spotify album URI" in caplog.text
 
     @responses.activate
-    @pytest.mark.parametrize(
-        "all_tracks,",
-        [(True), (False)],
-    )
+    @pytest.mark.parametrize("all_tracks", [True, False])
     def test_get_artist_albums(
         self,
         artist_albums_mock: dict[str, Any],


### PR DESCRIPTION
Fixes https://github.com/mopidy/mopidy-spotify/actions/runs/27987266520 which is broken on main.